### PR TITLE
Added an extra yaml file to the facts provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class mcollective (
   $rpcauthprovider = 'action_policy',
   $rpcauditprovider = 'logfile',
   $registration = undef,
+  $extra_yaml_paths = undef,
   $core_libdir = $mcollective::defaults::core_libdir,
   $site_libdir = $mcollective::defaults::site_libdir,
 

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -18,6 +18,6 @@ class mcollective::server::config::factsource::yaml {
   }
 
   mcollective::server::setting { 'plugin.yaml':
-    value => $mcollective::yaml_fact_path,
+    value =>  "${mcollective::yaml_fact_path}:${mcollective::extra_yaml_paths}"
   }
 }


### PR DESCRIPTION
This is a  proof of concept.  I needed to add a second yaml file to the fact config line, and this was the quickest way.


It's not perfect.  Could probably use an inline template with an index to do it correctly, along w/ building an array of the values.  

Wanted to see if the functionality is interesting before i bothered doing more than the basics.
