### PR TITLE
Make username configurable for middlware users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,18 @@ configuration file to use when configuring activemq middleware.  Bypasses
 String: default based on distribution.  The directory to copy ssl certificates
 to when configuring activemq middleware with `mcollective::middleware_ssl`.
 
+#### `activemq_user`
+String: defaults to 'activemq'. The name of the user which owns the
+activemq configuration files.
+
 ##### `rabbitmq_confdir`
 
 String: defaults to '/etc/rabbitmq'. The directory to copy ssl certificates to
 when configuring rabbitmq middleware with `mcollective::middleware_ssl`.
+
+#### `rabbitmq_user`
+String: defaults to 'rabbitmq'. The name of the user which owns the
+rabbitmq configuration files.
 
 ##### `rabbitmq_vhost`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,8 +10,10 @@ class mcollective (
   $activemq_console = false, # ubuntu why you no jetty.xml!
   $activemq_config = undef,
   $activemq_confdir = $mcollective::defaults::activemq_confdir,
+  $activemq_user = 'activemq',
   $rabbitmq_confdir = '/etc/rabbitmq',
   $rabbitmq_vhost = '/mcollective', # used by rabbitmq
+  $rabbitmq_user = 'rabbitmq',
   $delete_guest_user = false,
 
   # installing packages

--- a/manifests/middleware/activemq.pp
+++ b/manifests/middleware/activemq.pp
@@ -22,8 +22,8 @@ class mcollective::middleware::activemq {
     Class['activemq::packages'] ->
 
     file { "${mcollective::activemq_confdir}/ca.pem":
-      owner  => 'activemq',
-      group  => 'activemq',
+      owner  => $mcollective::activemq_user,
+      group  => $mcollective::activemq_user,
       mode   => '0444',
       source => $mcollective::ssl_ca_cert,
     } ->
@@ -37,21 +37,21 @@ class mcollective::middleware::activemq {
     } ->
 
     file { "${mcollective::activemq_confdir}/truststore.jks":
-      owner => 'activemq',
-      group => 'activemq',
+      owner => $mcollective::activemq_user,
+      group => $mcollective::activemq_user,
       mode  => '0400',
     } ->
 
     file { "${mcollective::activemq_confdir}/server_public.pem":
-      owner  => 'activemq',
-      group  => 'activemq',
+      owner  => $mcollective::activemq_user,
+      group  => $mcollective::activemq_user,
       mode   => '0444',
       source => $mcollective::ssl_server_public,
     } ->
 
     file { "${mcollective::activemq_confdir}/server_private.pem":
-      owner  => 'activemq',
-      group  => 'activemq',
+      owner  => $mcollective::activemq_user,
+      group  => $mcollective::activemq_user,
       mode   => '0400',
       source => $mcollective::ssl_server_private,
     } ->
@@ -66,8 +66,8 @@ class mcollective::middleware::activemq {
     } ->
 
     file { "${mcollective::activemq_confdir}/keystore.jks":
-      owner => 'activemq',
-      group => 'activemq',
+      owner => $mcollective::activemq_user,
+      group => $mcollective::activemq_user,
       mode  => '0400',
     } ->
 

--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -6,22 +6,22 @@ class mcollective::middleware::rabbitmq {
 
   if $mcollective::middleware_ssl {
     file { "${mcollective::rabbitmq_confdir}/ca.pem":
-      owner  => 'rabbitmq',
-      group  => 'rabbitmq',
+      owner  => $mcollective::rabbitmq_user,
+      group  => $mcollective::rabbitmq_user,
       mode   => '0444',
       source => $mcollective::ssl_ca_cert,
     }
 
     file { "${mcollective::rabbitmq_confdir}/server_public.pem":
-      owner  => 'rabbitmq',
-      group  => 'rabbitmq',
+      owner  => $mcollective::rabbitmq_user,
+      group  => $mcollective::rabbitmq_user,
       mode   => '0444',
       source => $mcollective::ssl_server_public,
     }
 
     file { "${mcollective::rabbitmq_confdir}/server_private.pem":
-      owner  => 'rabbitmq',
-      group  => 'rabbitmq',
+      owner  => $mcollective::rabbitmq_user,
+      group  => $mcollective::rabbitmq_user,
       mode   => '0400',
       source => $mcollective::ssl_server_private,
     }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -544,6 +544,17 @@ describe 'mcollective' do
             let(:params) { common_params }
             it { should contain_file('activemq.xml').with_content(/transportConnector name="stomp\+ssl" uri="stomp\+ssl:/) }
 
+            describe '#activemq_user' do
+              context 'should default to activemq' do
+                it { should contain_file('/etc/activemq/ca.pem').with_owner('activemq').with_group('activemq') }
+              end
+
+              context '_activemq' do
+                let(:params) { common_params.merge({ :activemq_user => 'activemq' }) }
+                it { should contain_file('/etc/activemq/ca.pem').with_owner('_activemq').with_group('_activemq') }
+              end
+            end
+
             describe '#ssl_ca_cert' do
               context 'set' do
                 let(:params) { common_params.merge({ :ssl_ca_cert => 'puppet:///modules/foo/ca_cert.pem' }) }
@@ -619,6 +630,17 @@ describe 'mcollective' do
 
           context 'true' do
             let(:params) { common_params.merge({ :middleware_ssl => true }) }
+
+            describe '#rabbitmq_user' do
+              context 'should default to rabbitmq' do
+                it { should contain_file('/etc/rabbitmq/ca.pem').with_owner('rabbitmq').with_group('rabbitmq') }
+              end
+
+              context '_rabbitmq' do
+                let(:params) { common_params.merge({ :rabbitmq_user => 'rabbitmq' }) }
+                it { should contain_file('/etc/rabbitmq/ca.pem').with_owner('_rabbitmq').with_group('_rabbitmq') }
+              end
+            end
 
             describe '#rabbitmq_confdir' do
               context 'default' do


### PR DESCRIPTION
On various systems, such as OpenBSD, user names provided by external packages are prefixed with an underscore.