### PR TITLE
yamlsource test needs to check for leading spaces

### DIFF
--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -159,7 +159,7 @@ describe 'mcollective' do
           it { should contain_file('/etc/mcollective/facts.yaml') }
           it do
             facts.keys.each do |k|
-              should_not contain_file('/etc/mcollective/facts.yaml').with_content(/^#{k.to_s}.*/m)
+              should_not contain_file('/etc/mcollective/facts.yaml').with_content(/^\s*#{k.to_s}.*/m)
             end
           end
         end


### PR DESCRIPTION
As yamlsource writes the fact names with leading spaces the regex needs to take those in consideration.
Without this change the test always passes even if the fact source filter would not remove the needed facts.