### PR TITLE
Adding relevant heartbeat config to common settings

### DIFF
--- a/manifests/common/config/connector/activemq.pp
+++ b/manifests/common/config/connector/activemq.pp
@@ -23,4 +23,9 @@ class mcollective::common::config::connector::activemq {
 
   $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::activemq::hosts_iteration { $indexes: }
+  
+  mcollective::common::setting { 'plugin.activemq.heartbeat_interval':
+    value => $mcollective::middleware_heartbeat_interval,
+  }
+
 }

--- a/manifests/common/config/connector/rabbitmq.pp
+++ b/manifests/common/config/connector/rabbitmq.pp
@@ -23,4 +23,9 @@ class mcollective::common::config::connector::rabbitmq {
 
   $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::rabbitmq::hosts_iteration { $indexes: }
+  
+  mcollective::common::setting { 'plugin.rabbitmq.heartbeat_interval':
+    value => $mcollective::middleware_heartbeat_interval,
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class mcollective (
   $middleware_ssl_fallback   = false,
   $middleware_admin_user     = 'admin',
   $middleware_admin_password = 'secret',
+  $middleware_heartbeat_interval = '30',
 
   # middleware connector tweaking
   $rabbitmq_vhost = '/mcollective',

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -211,6 +211,19 @@ describe 'mcollective' do
           it { should contain_mcollective__common__setting('plugin.activemq.pool.2.port').with_value('61613') }
         end
 
+        describe '#activemq_heartbeat' do
+        let(:common_params) { { :server => true } }
+        let(:params) { common_params }
+          context 'default' do
+            it { should contain_mcollective__common__setting('plugin.activemq.heartbeat_interval').with_value('30') }
+          end
+
+          context 'set' do
+            let(:params) { common_params.merge({ :middleware_heartbeat_interval => '20' }) }
+            it { should contain_mcollective__common__setting('plugin.activemq.heartbeat_interval').with_value('20') }
+          end
+        end
+
         describe '#middleware_user' do
           let(:params) { { :server => true, :middleware_hosts => %w{ foo } } }
           it 'should default to mcollective' do
@@ -318,6 +331,16 @@ describe 'mcollective' do
           context 'set' do
             let(:params) { common_params.merge({ :rabbitmq_vhost => '/pies' }) }
             it { should contain_mcollective__common__setting('plugin.rabbitmq.vhost').with_value('/pies') }
+          end
+        end
+        describe '#rabbitmq_heartbeat' do
+          context 'default' do
+            it { should contain_mcollective__common__setting('plugin.rabbitmq.heartbeat_interval').with_value('30') }
+          end
+
+          context 'set' do
+            let(:params) { common_params.merge({ :middleware_heartbeat_interval => '20' }) }
+            it { should contain_mcollective__common__setting('plugin.rabbitmq.heartbeat_interval').with_value('20') }
           end
         end
       end
@@ -510,6 +533,7 @@ describe 'mcollective' do
             it { should contain_mcollective__common__setting('plugin.activemq.pool.1.password').with_value('bob') }
           end
         end
+
 
         describe '#middleware_ssl' do
           let(:params) { { :server => false, :client => true, :middleware_hosts => %w{ foo } } }


### PR DESCRIPTION
Since the stomp connector was complaining about heartbeat not being set, I decided to expand the module to include a default heartbeat_interval of 30 secs, that can be overridden in the class declaration.