### PR TITLE
Added identity parameter so that hosts would export fqdn as identity.

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -54,6 +54,10 @@ class mcollective::common::config {
     value => $mcollective::main_collective,
   }
 
+ mcollective::common::setting { 'identity':
+    value => $mcollective::identity,
+  }
+
   mcollective::soft_include { [
     "::mcollective::common::config::connector::${mcollective::connector}",
     "::mcollective::common::config::securityprovider::${mcollective::securityprovider}",

--- a/manifests/common/config/connector/activemq.pp
+++ b/manifests/common/config/connector/activemq.pp
@@ -15,6 +15,10 @@ class mcollective::common::config::connector::activemq {
   mcollective::common::setting { 'plugin.activemq.randomize':
     value => 'true',
   }
+  
+  mcollective::common::setting { 'plugin.activemq.heartbeat_interval':
+    value => 30,
+  }
 
   $pool_size = size($mcollective::middleware_hosts)
   mcollective::common::setting { 'plugin.activemq.pool.size':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class mcollective (
   $registration = undef,
   $core_libdir = $mcollective::defaults::core_libdir,
   $site_libdir = $mcollective::defaults::site_libdir,
+  $identity = $fqdn,
 
   # networking
   $middleware_hosts = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,10 @@ class mcollective (
   $server_config_file = '/etc/mcollective/server.cfg',
   $server_logfile   = '/var/log/mcollective.log',
   $server_loglevel  = 'info',
-  $server_daemonize = 1,
+  case $::operatingsystem {
+    Ubuntu : {  $server_daemonize = 0,}
+    default: { $server_daemonize = 1,}
+  }
 
   # client-specific
   $client_config_file = '/etc/mcollective/client.cfg',


### PR DESCRIPTION


While using Mcollective with Foreman, if hosts are not exporting fqdn to mcollective, 'puppet run' from foreman would not work, as foreman-proxy uses fqdn for 'mco puppet runonce ' command .

Socket.gethostname is used for finding identity by default and could give just hostname in configurations like following..

[root@centos ~]# cat /etc/sysconfig/network
NETWORKING=yes
HOSTNAME=centos
DOMAINNAME=ppp.com

1.9.3-p484 :002 > Socket.gethostname
 => "centos" 

Facter is more reliable..

# facter fqdn
centos.ppp.com