### PR TITLE
Add show_diff => false to private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ internally: `uptime.*`, `rubysitedir`, `_timestamp`, `memoryfree.*`,
 `swapfree.*` and `last_run`. Note that the fact names can be Ruby regular
 expressions.
 
+##### `show_fact_diff`
+Boolean: defaults to true. Whether to generate a diff for the generated
+facts.yaml file. Set this to false if your facts contain private information.
+
 ##### `classesfile`
 
 String: defaults to '/var/lib/puppet/state/classes.txt'.  Name of the file the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class mcollective (
   $factsource = 'yaml',
   $yaml_fact_path = '/etc/mcollective/facts.yaml',
   $excluded_facts = [],
+  $show_fact_diff = true,
   $classesfile = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider = 'action_policy',
   $rpcauditprovider = 'logfile',

--- a/manifests/middleware/activemq.pp
+++ b/manifests/middleware/activemq.pp
@@ -49,7 +49,7 @@ class mcollective::middleware::activemq {
       source => $mcollective::ssl_server_public,
     } ->
 
-    file { "${mcollective::activemq_confdir}/server_private.pem":
+    mcollective::secret_file { "${mcollective::activemq_confdir}/server_private.pem":
       owner  => 'activemq',
       group  => 'activemq',
       mode   => '0400',

--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -19,7 +19,7 @@ class mcollective::middleware::rabbitmq {
       source => $mcollective::ssl_server_public,
     }
 
-    file { "${mcollective::rabbitmq_confdir}/server_private.pem":
+    mcollective::secret_file { "${mcollective::rabbitmq_confdir}/server_private.pem":
       owner  => 'rabbitmq',
       group  => 'rabbitmq',
       mode   => '0400',

--- a/manifests/secret_file.pp
+++ b/manifests/secret_file.pp
@@ -1,0 +1,25 @@
+# private define - mcollective::secret_file
+#
+# wrapper around 'file' resource that sets show_diff to
+# false when running on puppet 3.2+ and is_secret is true.
+
+define mcollective::secret_file(
+  $owner     = undef,
+  $group     = undef,
+  $mode      = undef,
+  $source    = undef,
+  $content   = undef,
+  $is_secret = true,
+) {
+  if $is_secret and versioncmp($settings::puppetversion, '3.2.0') >= 0 {
+    File { show_diff => false }
+  }
+
+  file { $title:
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    source  => $source,
+    content => $content,
+  }
+}

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -50,7 +50,7 @@ class mcollective::server::config {
       source => $mcollective::ssl_server_public,
     }
 
-    file { '/etc/mcollective/server_private.pem':
+    mcollective::secret_file { '/etc/mcollective/server_private.pem':
       owner  => 'root',
       group  => '0',
       mode   => '0400',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -8,11 +8,12 @@ class mcollective::server::config::factsource::yaml {
 
   # This pattern originally from
   # http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
-  file { $mcollective::yaml_fact_path:
-    owner   => 'root',
-    group   => '0',
-    mode    => '0400',
-    content => template('mcollective/facts.yaml.erb'),
+  mcollective::secret_file { $mcollective::yaml_fact_path:
+    owner     => 'root',
+    group     => '0',
+    mode      => '0400',
+    content   => template('mcollective/facts.yaml.erb'),
+    is_secret => !$mcollective::show_fact_diff,
   }
 
   mcollective::server::setting { 'factsource':

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -52,7 +52,7 @@ define mcollective::user(
     }
 
     $private_path = "${homedir}/.mcollective.d/credentials/private_keys/${username}.pem"
-    file { $private_path:
+    mcollective::secret_file { $private_path:
       source => $private_key,
       owner  => $username,
       group  => $group,


### PR DESCRIPTION
Use show_diff => false in file resources that put private keys in
place to prevent both the old and the new one from showing up in
the diff.