### PR TITLE
Remove Erlang module dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,10 +12,6 @@
       "version_requirement": "0.4.x"
     },
     {
-      "name": "garethr/erlang",
-      "version_requirement": ">=0.1.0"
-    },
-    {
       "name": "puppetlabs/rabbitmq",
       "version_requirement": ">=1.0.0"
     },

--- a/spec/fixtures/data/rabbitmq.foo.vm.json
+++ b/spec/fixtures/data/rabbitmq.foo.vm.json
@@ -1,4 +1,3 @@
 {
-    "erlang::epel_enable": "true",
     "mcollective::connector": "rabbitmq"
 }


### PR DESCRIPTION
The rabbitMQ module no longer requires it, so we shouldn't either.