### PR TITLE
Verify ssl certs on the RabbitMQ server

### DIFF
--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -34,6 +34,8 @@ class mcollective::middleware::rabbitmq {
     ssl               => $mcollective::middleware_ssl,
     stomp_port        => $mcollective::middleware_port,
     ssl_stomp_port    => $mcollective::middleware_ssl_port,
+    ssl_verify               => 'verify_peer',
+    ssl_fail_if_no_peer_cert => true,
     ssl_cacert        => "${mcollective::rabbitmq_confdir}/ca.pem",
     ssl_cert          => "${mcollective::rabbitmq_confdir}/server_public.pem",
     ssl_key           => "${mcollective::rabbitmq_confdir}/server_private.pem",

--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -29,16 +29,16 @@ class mcollective::middleware::rabbitmq {
 
   anchor { 'mcollective::middleware::rabbitmq::start': }
   class { '::rabbitmq':
-    config_stomp      => true,
-    delete_guest_user => $mcollective::delete_guest_user,
-    ssl               => $mcollective::middleware_ssl,
-    stomp_port        => $mcollective::middleware_port,
-    ssl_stomp_port    => $mcollective::middleware_ssl_port,
+    config_stomp             => true,
+    delete_guest_user        => $mcollective::delete_guest_user,
+    ssl                      => $mcollective::middleware_ssl,
+    stomp_port               => $mcollective::middleware_port,
+    ssl_stomp_port           => $mcollective::middleware_ssl_port,
     ssl_verify               => 'verify_peer',
     ssl_fail_if_no_peer_cert => true,
-    ssl_cacert        => "${mcollective::rabbitmq_confdir}/ca.pem",
-    ssl_cert          => "${mcollective::rabbitmq_confdir}/server_public.pem",
-    ssl_key           => "${mcollective::rabbitmq_confdir}/server_private.pem",
+    ssl_cacert               => "${mcollective::rabbitmq_confdir}/ca.pem",
+    ssl_cert                 => "${mcollective::rabbitmq_confdir}/server_public.pem",
+    ssl_key                  => "${mcollective::rabbitmq_confdir}/server_private.pem",
   } ->
 
   rabbitmq_plugin { 'rabbitmq_stomp':


### PR DESCRIPTION
See MODULES-971 for details.  This forces bidirectional certificate checking, and ensures that all mco connections on SSL port are from a cert issued by the CA.  