### PR TITLE
Adjust mcollective::middleware::rabbitmq to handle installing the stomp plugin correctly.

### DIFF
--- a/manifests/middleware/rabbitmq.pp
+++ b/manifests/middleware/rabbitmq.pp
@@ -33,14 +33,11 @@ class mcollective::middleware::rabbitmq {
     delete_guest_user => $mcollective::delete_guest_user,
     ssl               => $mcollective::middleware_ssl,
     stomp_port        => $mcollective::middleware_port,
+    stomp_ensure      => true,
     ssl_stomp_port    => $mcollective::middleware_ssl_port,
     ssl_cacert        => "${mcollective::rabbitmq_confdir}/ca.pem",
     ssl_cert          => "${mcollective::rabbitmq_confdir}/server_public.pem",
     ssl_key           => "${mcollective::rabbitmq_confdir}/server_private.pem",
-  } ->
-
-  rabbitmq_plugin { 'rabbitmq_stomp':
-    ensure => present,
   } ->
 
   rabbitmq_vhost { $mcollective::rabbitmq_vhost:


### PR DESCRIPTION
Currently the rabbitmq middleware class leaves rabbitmq configured to use stomp but running a version configured prior to stomp being configured and requiring a manual restart of the service.

The dependency rabbitmq module should already handle installing the stomp plugin and properly setting the necessary resource ordering to ensure we are left in a functional state but has minor errors being addressed in https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/206 and https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/205.

