### PR TITLE
Modules 1192 - rename facts param on actionpolicy::rule to remove conflict with $facts hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,13 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.7.0" TRUSTED_NODE_DATA="yes"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.7.0" TRUSTED_NODE_DATA="yes"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake'
-  gem 'puppetlabs_spec_helper'
+  gem 'puppetlabs_spec_helper', '>= 0.7.0', :require => false
+  gem 'rspec-system-puppet', '~>2.0'
   gem 'puppet-lint'
 end
 

--- a/README.md
+++ b/README.md
@@ -560,7 +560,8 @@ String: defaults to 'deny'.  The default actionpolicy to apply to the agent.
 ### `mcollective::actionpolicy::rule` defined type
 
 `mcollective::actionpolicy::rule` represents a single actionpolicy policy
-entry.
+entry. See the actionpolicy plugin [Policy File Format](https://github.com/puppetlabs/mcollective-actionpolicy-auth#policy-file-format)
+for specific restrictions on the values of these fields.
 
 #### Parameters
 
@@ -586,9 +587,11 @@ String: defaults to '*'.  What callerids should match this rule.
 
 String: defaults to '*'.  What actions should match this rule.
 
-##### `facts`
+##### `fact_filter`
 
-String: defaults to '*'.  What facts should match this rule.
+String: defaults to '*'.  What facts should match this rule. This can be either
+'*', a space-separated list of ``fact=value`` pairs (which match if every listed
+fact matches), or any valid [compound filter string](http://docs.puppetlabs.com/mcollective/reference/basic/basic_cli_usage.html#complex-compound-or-select-queries). This matches the "facts" field of the policy file lines.
 
 ##### `classes`
 

--- a/manifests/actionpolicy/rule.pp
+++ b/manifests/actionpolicy/rule.pp
@@ -1,12 +1,13 @@
 # Define - mcollective::actionpolicy::rule
 define mcollective::actionpolicy::rule(
   $agent,
-  $action   = 'allow',
-  $callerid = '*',
-  $actions  = '*',
-  $facts = '*',
-  $classes = '*'
+  $action      = 'allow',
+  $callerid    = '*',
+  $actions     = '*',
+  $fact_filter = '*',
+  $classes     = '*'
 ) {
+  validate_string($fact_filter)
   datacat_fragment { "mcollective::actionpolicy::rule ${title}":
     target => "mcollective::actionpolicy ${agent}",
     data   => {
@@ -15,7 +16,7 @@ define mcollective::actionpolicy::rule(
           'action'   => $action,
           'callerid' => $callerid,
           'actions'  => $actions,
-          'facts'    => $facts,
+          'facts'    => $fact_filter,
           'classes'  => $classes,
         },
       ],

--- a/spec/defines/mcollective__actionpolicy__rule_spec.rb
+++ b/spec/defines/mcollective__actionpolicy__rule_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'mcollective::actionpolicy::rule', :type => :define do
+  context 'default-puppet' do
+    let(:title) { 'default-puppet' }
+    let(:params) do
+      {
+        :agent => 'puppet',
+      }
+    end
+
+    it {
+      should contain_datacat_fragment('mcollective::actionpolicy::rule default-puppet') \
+        .with_target('mcollective::actionpolicy puppet') \
+        .with_data({
+          'lines' => [
+            {
+              'action'   => 'allow',
+              'callerid' => '*',
+              'actions'  => '*',
+              'facts'    => '*',
+              'classes'  => '*',
+            },
+          ],
+        })
+      }
+  end
+
+  context 'facts-specified' do
+    let(:title) { 'default-puppet' }
+    let(:params) do
+      {
+        :agent       => 'puppet',
+        :fact_filter => 'environment=dev and !customer=acme',
+      }
+    end
+
+    it {
+      should contain_datacat_fragment('mcollective::actionpolicy::rule default-puppet') \
+        .with_target('mcollective::actionpolicy puppet') \
+        .with_data({
+          'lines' => [
+            {
+              'action'   => 'allow',
+              'callerid' => '*',
+              'actions'  => '*',
+              'facts'    => 'environment=dev and !customer=acme',
+              'classes'  => '*',
+            },
+          ],
+        })
+      }
+  end
+end

--- a/templates/actionpolicy.erb
+++ b/templates/actionpolicy.erb
@@ -1,7 +1,7 @@
 policy default <%= @data['default'] %>
 <%
     lines = @data['lines'].collect do |line|
-      line.values_at(*%w{ action callerid actions facts classes }).join("\t")
+      line.values_at(*%w{ action callerid actions fact_filter classes }).join("\t")
     end
 -%>
 <%= lines.sort.join("\n") %>


### PR DESCRIPTION
The gist of MODULES-1192 is that ``trusted_node_data=true`` is now (3.6) a "recommended and safe" puppet config setting; this enables the ``$facts`` hash, which makes ``$facts`` a reserved variable and therefore ``mcollective::actionpolicy::rule`` generates a compile-time failure.

This branch will probably need some fixup by me, but I've included my intermediate work in order to fully test and convey what I've done:
* pull in puppetlabs_spec_helper from master, to include not-yet-released https://github.com/puppetlabs/puppetlabs_spec_helper/pull/70 which lets us configure ``trusted_node_data``
* add missing test environments for 3.5.0 and 3.6.0 with strict_variables set to true; also add 3.6.0 test environments with future parser, and with future parser and trusted_node_data (the latter being the one of relevance to this ticket). IMO, we should keep the first and last of these - 3.5.0 with strict variables set, and 3.6.0 with both future parser and trusted_node_data, the latter being the most future-proof at the moment (as far as I know)
* add spec tests for the ``mcollective::actionpolicy::rule`` define, which was previously untested. Add one that uses the facts parameter.
* rename the param on ``mcollective::actionpolicy::rule`` from "facts" to "fact_filter" (this is the actual MODULES-1192 work). I've updated the README appropriately for the new param, but I'm not sure what the correct place is to document essentially a breaking change (side note on this - as I mentioned in the Jira ticket, I was unable to find a single piece of public code that uses this param).