### PR TITLE
Parameterise $confdir and service name

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,15 @@
+name 'puppetlabs-mcollective'
+author 'puppetlabs'
+version '1.1.5'
+source 'https://github.com/puppetlabs/puppetlabs-mcollective'
+project_page 'https://github.com/puppetlabs/puppetlabs-mcollective'
+license 'Apache License, Version 2.0'
+description 'MCollective Puppet Module'
+summary 'MCollective Puppet Module'
+
+dependency "puppetlabs/activemq", "0.2.x"
+dependency "richardc/datacat", "0.4.x"
+dependency "garethr/erlang", ">=0.1.0"
+dependency "puppetlabs/rabbitmq", ">=1.0.0"
+dependency "puppetlabs/stdlib", ">=1.0.0"
+dependency "puppetlabs/java_ks", ">=1.0.0"

--- a/manifests/actionpolicy.pp
+++ b/manifests/actionpolicy.pp
@@ -7,7 +7,7 @@ define mcollective::actionpolicy($default = 'deny') {
     owner    => 'root',
     group    => '0',
     mode     => '0400',
-    path     => "/etc/mcollective/policies/${name}.policy",
+    path     => "${mcollective::confdir}/policies/${name}.policy",
     template => 'mcollective/actionpolicy.erb',
   }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,5 +1,5 @@
 # private class
-# Installs the client and sets up /etc/mcollective/client.cfg (global/common
+# Installs the client and sets up $confdir/client.cfg (global/common
 # configuration)
 class mcollective::client {
   if $caller_module_name != $module_name {

--- a/manifests/common/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/common/config/connector/activemq/hosts_iteration.pp
@@ -33,7 +33,7 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.ca":
-      value => '/etc/mcollective/ca.pem',
+      value => "${mcollective::confdir}/ca.pem",
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.fallback":

--- a/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
@@ -28,7 +28,7 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     }
 
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl.ca":
-      value => '/etc/mcollective/ca.pem',
+      value => "${mcollective::confdir}/ca.pem",
     }
 
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl.fallback":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@ class mcollective (
   $version = 'present',
   $ruby_stomp_ensure = 'installed',
 
+  # file layout
+  $confdir = '/etc/mcollective',
+
   # core configuration
   $main_collective = 'mcollective',
   $collectives = 'mcollective',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,9 @@ class mcollective (
   $ssl_server_public = undef,
   $ssl_server_private = undef,
   $ssl_client_certs = 'puppet:///modules/mcollective/empty',
+
+  # service
+  $service_name = 'mcollective',
 ) inherits mcollective::defaults {
   anchor { 'mcollective::begin': }
   anchor { 'mcollective::end': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class mcollective (
   $middleware_password = 'marionette',
   $middleware_port = '61613',
   $middleware_ssl_port = '61614',
+  $middleware_ssl_protocols = 'TLSv1,TLSv1.1,TLSv1.2',
   $middleware_ssl = false,
   $middleware_ssl_fallback = false,
   $middleware_admin_user = 'admin',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,6 +7,8 @@ class mcollective::server {
   anchor { 'mcollective::server::begin': } ->
   class { '::mcollective::server::install': } ->
   class { '::mcollective::server::config': } ~>
-  class { '::mcollective::server::service': } ->
+  class { '::mcollective::server::service':
+    service_name => $mcollective::service_name,
+  } ->
   anchor { 'mcollective::server::end': }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -28,7 +28,7 @@ class mcollective::server::config {
     value => $mcollective::server_loglevel,
   }
 
-  file { '/etc/mcollective/policies':
+  file { "${mcollective::confdir}/policies":
     ensure => 'directory',
     owner  => 'root',
     group  => '0',
@@ -36,21 +36,21 @@ class mcollective::server::config {
   }
 
   if $mcollective::middleware_ssl or $mcollective::securityprovider == 'ssl' {
-    file { '/etc/mcollective/ca.pem':
+    file { "${mcollective::confdir}/ca.pem":
       owner  => 'root',
       group  => '0',
       mode   => '0444',
       source => $mcollective::ssl_ca_cert,
     }
 
-    file { '/etc/mcollective/server_public.pem':
+    file { "${mcollective::confdir}/server_public.pem":
       owner  => 'root',
       group  => '0',
       mode   => '0444',
       source => $mcollective::ssl_server_public,
     }
 
-    file { '/etc/mcollective/server_private.pem':
+    file { "${mcollective::confdir}/server_private.pem":
       owner  => 'root',
       group  => '0',
       mode   => '0400',

--- a/manifests/server/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/server/config/connector/activemq/hosts_iteration.pp
@@ -3,11 +3,11 @@
 define mcollective::server::config::connector::activemq::hosts_iteration {
   if $mcollective::middleware_ssl {
     mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.cert":
-      value => '/etc/mcollective/server_public.pem',
+      value => "${mcollective::confdir}/server_public.pem",
     }
 
     mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.key":
-      value => '/etc/mcollective/server_private.pem',
+      value => "${mcollective::confdir}/server_private.pem",
     }
   }
 }

--- a/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
@@ -3,11 +3,11 @@
 define mcollective::server::config::connector::rabbitmq::hosts_iteration {
   if $mcollective::middleware_ssl {
     mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.cert":
-      value => '/etc/mcollective/server_public.pem',
+      value => "${mcollective::confdir}/server_public.pem",
     }
 
     mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.key":
-      value => '/etc/mcollective/server_private.pem',
+      value => "${mcollective::confdir}/server_private.pem",
     }
   }
 }

--- a/manifests/server/config/securityprovider/ssl.pp
+++ b/manifests/server/config/securityprovider/ssl.pp
@@ -4,7 +4,7 @@ class mcollective::server::config::securityprovider::ssl {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  file { '/etc/mcollective/clients':
+  file { "${mcollective::confdir}/clients":
     ensure  => 'directory',
     owner   => 'root',
     group   => '0',
@@ -15,14 +15,14 @@ class mcollective::server::config::securityprovider::ssl {
   }
 
   mcollective::server::setting { 'plugin.ssl_client_cert_dir':
-    value => '/etc/mcollective/clients',
+    value => "${mcollective::confdir}/clients",
   }
 
   mcollective::server::setting { 'plugin.ssl_server_public':
-    value => '/etc/mcollective/server_public.pem',
+    value => "${mcollective::confdir}/server_public.pem",
   }
 
   mcollective::server::setting { 'plugin.ssl_server_private':
-    value => '/etc/mcollective/server_private.pem',
+    value => "${mcollective::confdir}/server_private.pem",
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,10 +1,10 @@
 # private class
-class mcollective::server::service {
+class mcollective::server::service($service_name) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  service { 'mcollective':
+  service { $service_name:
     ensure => 'running',
     enable => true,
   }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -714,6 +714,11 @@ describe 'mcollective' do
             it { should contain_file('activemq.xml').with_content(/transportConnector name="stomp\+ssl" uri="stomp\+ssl:.*?:61614\?/) }
           end
 
+          context 'TLS enabled' do
+            let(:params) { common_params.merge({ :middleware_ssl_protocols => 'abc,def'})}
+            it { should contain_file('activemq.xml').with_content(/transportConnector name="stomp\+ssl" uri="stomp\+ssl:.*?:61614\?needClientAuth=true&amp;transport\.enabledProtocols=#{params[:middleware_ssl_protocols]}/) }
+          end
+
           context 'set' do
             let(:params) { common_params.merge({ :middleware_ssl_port => '1702' }) }
             it { should contain_file('activemq.xml').with_content(/transportConnector name="stomp\+ssl" uri="stomp\+ssl:.*?:1702\?/) }

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -130,7 +130,9 @@
         -->
         <transportConnectors>
         <% if scope['mcollective::middleware_ssl'] %>
-            <transportConnector name="stomp+ssl" uri="stomp+ssl://0.0.0.0:<%= scope['mcollective::middleware_ssl_port'] %>?needClientAuth=true"/>
+            <transportConnector name="stomp+ssl" uri="stomp+ssl://0.0.0.0:<%= scope['mcollective::middleware_ssl_port'] %>?needClientAuth=true<%- if scope['mcollective::middleware_ssl_protocols'] -%>
+&amp;transport.enabledProtocols=<%= scope['mcollective::middleware_ssl_protocols'] -%>
+            <%- end -%>"/>
         <% else %>
             <transportConnector name="stomp" uri="stomp://0.0.0.0:<%= scope['mcollective::middleware_port'] %>"/>
         <% end %>


### PR DESCRIPTION
Add additional parameter `$confdir` to allow installation of mcollective configuration into a non-standard location and `$service_name` to enable changing service name.

Use case was to support deployment side-by-side with an existing (depreciated) mcollective deployment, but maybe it will be useful for others. 