### PR TITLE
Add argument to disable yaml cronjob when factsource => yaml

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class mcollective (
   $psk              = 'changemeplease',
   $factsource       = 'yaml',
   $yaml_fact_path   = undef,
+  $yaml_fact_cron   = true,
   $excluded_facts   = [],
   $classesfile      = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider  = 'action_policy',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -19,7 +19,7 @@ class mcollective::server::config::factsource::yaml {
   if $yaml_fact_cron {
     cron { 'refresh-mcollective-metadata':
       environment => "PATH=/opt/puppet/bin:${::path}",
-      command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
+      command     => "${mcollective::core_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
       user        => 'root',
       minute      => [ '0', '15', '30', '45' ],
       require     => File["${mcollective::core_libdir}/refresh-mcollective-metadata"],

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,6 +6,7 @@ class mcollective::server::config::factsource::yaml {
 
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
+  $yaml_fact_cron      = $mcollective::yaml_fact_cron
 
   # Template uses:
   #   - $yaml_fact_path_real
@@ -16,11 +17,13 @@ class mcollective::server::config::factsource::yaml {
     content => template('mcollective/refresh-mcollective-metadata.erb'),
     before  => Cron['refresh-mcollective-metadata'],
   }
-  cron { 'refresh-mcollective-metadata':
-    environment => "PATH=/opt/puppet/bin:${::path}",
-    command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
-    user        => 'root',
-    minute      => [ '0', '15', '30', '45' ],
+  if $yaml_fact_cron {
+    cron { 'refresh-mcollective-metadata':
+      environment => "PATH=/opt/puppet/bin:${::path}",
+      command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
+      user        => 'root',
+      minute      => [ '0', '15', '30', '45' ],
+    }
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -15,7 +15,6 @@ class mcollective::server::config::factsource::yaml {
     group   => '0',
     mode    => '0755',
     content => template('mcollective/refresh-mcollective-metadata.erb'),
-    before  => Cron['refresh-mcollective-metadata'],
   }
   if $yaml_fact_cron {
     cron { 'refresh-mcollective-metadata':
@@ -23,6 +22,7 @@ class mcollective::server::config::factsource::yaml {
       command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
       user        => 'root',
       minute      => [ '0', '15', '30', '45' ],
+      require     => File["${mcollective::core_libdir}/refresh-mcollective-metadata"],
     }
   }
   exec { 'create-mcollective-metadata':

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -145,6 +145,17 @@ describe 'mcollective' do
             it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
           end
         end
+
+        describe '#yaml_fact_cron' do
+          context 'default (true)' do
+            it { should contain_cron('refresh-mcollective-metadata') }
+          end
+
+          context 'false' do
+            let(:params) { { :server => false } }
+            it { should_not contain_cron('refresh-mcollective-metadata') }
+          end
+        end
       end
 
       context 'facter' do

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -152,7 +152,7 @@ describe 'mcollective' do
           end
 
           context 'false' do
-            let(:params) { { :server => false } }
+            let(:params) { { :yaml_fact_cron => false } }
             it { should_not contain_cron('refresh-mcollective-metadata') }
           end
         end


### PR DESCRIPTION
The `$::path` variable was messing a lot with multiple distributions...

```
puppet agent -t  on centos : PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
puppet agent -t on debian: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
automated run (/etc/init.d/puppet) centos: PATH=/usr/bin:/sbin:/bin:/usr/sbin
automated run (/etc/init.d/puppet) debian: PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
```
(packages from puppetlabs: 3.6.2-1.el6 and 3.6.2-1puppetlabs1)