### PR TITLE
(MODULES-773) Use mco_array_to_string() in more locations

### DIFF
--- a/manifests/common/config/connector/rabbitmq.pp
+++ b/manifests/common/config/connector/rabbitmq.pp
@@ -21,6 +21,6 @@ class mcollective::common::config::connector::rabbitmq {
     value => $pool_size,
   }
 
-  $indexes = range('1', $pool_size)
+  $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::common::config::connector::rabbitmq::hosts_iteration { $indexes: }
 }

--- a/manifests/server/config/connector/activemq.pp
+++ b/manifests/server/config/connector/activemq.pp
@@ -7,6 +7,6 @@ class mcollective::server::config::connector::activemq {
   # Oh puppet!  Fake iteration of the indexes (+1 as plugin.activemq.pool is
   # 1-based)
   $pool_size = size(flatten([$mcollective::middleware_hosts]))
-  $indexes = range('1', $pool_size)
+  $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::server::config::connector::activemq::hosts_iteration { $indexes: }
 }

--- a/manifests/server/config/connector/rabbitmq.pp
+++ b/manifests/server/config/connector/rabbitmq.pp
@@ -7,6 +7,6 @@ class mcollective::server::config::connector::rabbitmq {
   # Oh puppet!  Fake iteration of the indexes (+1 as plugin.activemq.pool is
   # 1-based)
   $pool_size = size(flatten([$mcollective::middleware_hosts]))
-  $indexes = range('1', $pool_size)
+  $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::server::config::connector::rabbitmq::hosts_iteration { $indexes: }
 }


### PR DESCRIPTION
The fix committed in e750b674f7f0 is on the right track, but incomplete. This
commit uses `mco_array_to_string()` in three more locations affected by the same
bug, allowing the module to work with the future parser as of Puppet 3.7.0.