### PR TITLE
Re-introduce excluded_facts functionality for yaml factsource

### DIFF
--- a/templates/refresh-mcollective-metadata.erb
+++ b/templates/refresh-mcollective-metadata.erb
@@ -5,7 +5,13 @@ require 'facter/application'
 
 Facter::Application.load_puppet
 
-facts = YAML.dump(Facter.to_hash)
+excluded_facts_re = Regexp.new( "^(<%= @excluded_facts.join("|") %>)$", true)
+
+facts_hash = Facter.to_hash
+facts_hash = facts_hash.reject { |k,v|
+  k.to_s =~ excluded_facts_re
+}
+facts = YAML.dump(facts_hash)
 
 File.open('<%= @yaml_fact_path_real -%>.new', 'w') do |f|
   f.puts facts


### PR DESCRIPTION
A side-effect of commit d7290fc14b34 removes the ability to filter certain facts
from `facts.yaml`. This commit restores this functionality.