### PR TITLE
Allow mcollective::common::setting to be overridden

### DIFF
--- a/manifests/common/setting.pp
+++ b/manifests/common/setting.pp
@@ -4,7 +4,7 @@ define mcollective::common::setting (
   $setting = $name,
   $order = '10',
 ) {
-  mcollective::setting { "mcollective::common::setting ${setting}":
+  mcollective::setting { "mcollective::common::setting ${title}":
     setting => $setting,
     value   => $value,
     target  => [ 'mcollective::server', 'mcollective::client' ],

--- a/spec/defines/mcollective__common__setting_spec.rb
+++ b/spec/defines/mcollective__common__setting_spec.rb
@@ -9,4 +9,13 @@ describe 'mcollective::common::setting' do
     it { should contain_mcollective__setting('mcollective::common::setting some_setting').with_value('pie') }
     it { should contain_mcollective__setting('mcollective::common::setting some_setting').with_target(%w[ mcollective::server mcollective::client ]) }
   end
+
+  context 'some_setting with different title' do
+    let(:title) { 'some_other_setting' }
+    let(:params) { { 'setting' => 'some_setting', 'value' => 'pie' } }
+    it { should contain_mcollective__setting('mcollective::common::setting some_other_setting') }
+    it { should contain_mcollective__setting('mcollective::common::setting some_other_setting').with_setting('some_setting') }
+    it { should contain_mcollective__setting('mcollective::common::setting some_other_setting').with_value('pie') }
+    it { should contain_mcollective__setting('mcollective::common::setting some_other_setting').with_target(%w[ mcollective::server mcollective::client ]) }
+  end
 end


### PR DESCRIPTION
mcollective::common::setting was intended to follow the same pattern as
mcollective::client::setting and mcollective::server::setting, but it was
overlooked when initially written.

This patch enables this pattern as was originally intended:

    mcollective::common::setting { 'daemonize':
      value => 1,
    }

    # at some distance
    mcollective::common::setting { 'override daemonize':
      setting => 'daemonize',
      value => 0,
      order => 90,
    }