### PR TITLE
Use mco_array_to_string() for activemq server config hosts_iteration...

### DIFF
--- a/manifests/server/config/connector/activemq.pp
+++ b/manifests/server/config/connector/activemq.pp
@@ -7,6 +7,6 @@ class mcollective::server::config::connector::activemq {
   # Oh puppet!  Fake iteration of the indexes (+1 as plugin.activemq.pool is
   # 1-based)
   $pool_size = size(flatten([$mcollective::middleware_hosts]))
-  $indexes = range('1', $pool_size)
+  $indexes = mco_array_to_string(range('1', $pool_size))
   mcollective::server::config::connector::activemq::hosts_iteration { $indexes: }
 }


### PR DESCRIPTION
I believe mc_array_to_string() from #171 needs to be applied to the range() in manifests/server/config/connector/activemq.pp.  Without this I'm getting the "Expected String, got Integer" error with Puppet 3.7.1.

-a