### PR TITLE
Add middleware_ssl_* parameters

### DIFF
--- a/manifests/common/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/common/config/connector/activemq/hosts_iteration.pp
@@ -34,7 +34,7 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.ca":
-      value => "${mcollective::confdir}/ca.pem",
+      value => $::mcollective::middleware_ssl_ca_path,
     }
 
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl.fallback":

--- a/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
@@ -33,7 +33,7 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     }
 
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl.ca":
-      value => "${mcollective::confdir}/ca.pem",
+      value => $::mcollective::middleware_ssl_ca_path,
     }
 
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl.fallback":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@ class mcollective (
   $middleware_ssl_port       = '61614',
   $middleware_ssl            = false,
   $middleware_ssl_fallback   = false,
+  $middleware_ssl_cert       = '',
+  $middleware_ssl_key        = '',
+  $middleware_ssl_ca         = '',
   $middleware_admin_user     = 'admin',
   $middleware_admin_password = 'secret',
   $middleware_heartbeat_interval = '30',
@@ -71,7 +74,21 @@ class mcollective (
   $yaml_fact_path_real = pick($yaml_fact_path, "${confdir}/facts.yaml")
   $server_config_file_real = pick($server_config_file, "${confdir}/server.cfg")
   $client_config_file_real = pick($client_config_file, "${confdir}/client.cfg")
+
   $ssl_client_certs_dir_real = pick($ssl_client_certs_dir, "${confdir}/clients")
+  $ssl_server_public_path = "${confdir}/ssl/server_public.pem"
+  $ssl_server_private_path = "${confdir}/ssl/server_private.pem"
+
+  $middleware_ssl_ca_real = pick($middleware_ssl_ca, $ssl_ca_cert)
+  $middleware_ssl_cert_real =  pick($middleware_ssl_cert, $ssl_server_public)
+  $middleware_ssl_key_real =  pick($middleware_ssl_key, $ssl_server_private)
+
+  $middleware_ssl_key_path = "${confdir}/ssl/middleware_key.pem"
+  $middleware_ssl_cert_path = "${confdir}/ssl/middleware_cert.pem"
+  $middleware_ssl_ca_path = "${confdir}/ssl/middleware_ca.pem"
+
+
+
 
   if $client or $server {
     contain mcollective::common

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -35,27 +35,48 @@ class mcollective::server::config {
     mode   => '0700',
   }
 
-  if $mcollective::middleware_ssl or $mcollective::securityprovider == 'ssl' {
-    file { "${mcollective::confdir}/ca.pem":
+  if $mcollective::middleware_ssl {
+
+    file { $::mcollective::middleware_ssl_ca_path:
       owner  => 'root',
       group  => '0',
       mode   => '0444',
-      source => $mcollective::ssl_ca_cert,
+      source => $::mcollective::middleware_ssl_ca_real,
     }
 
-    file { "${mcollective::confdir}/server_public.pem":
-      owner  => 'root',
-      group  => '0',
-      mode   => '0444',
-      source => $mcollective::ssl_server_public,
-    }
-
-    file { "${mcollective::confdir}/server_private.pem":
+    file { $::mcollective::middleware_ssl_key_path:
       owner  => 'root',
       group  => '0',
       mode   => '0400',
-      source => $mcollective::ssl_server_private,
+      source => $::mcollective::middleware_ssl_key_real,
     }
+
+    file { $::mcollective::middleware_ssl_cert_path:
+      owner  => 'root',
+      group  => '0',
+      mode   => '0444',
+      source => $::mcollective::middleware_ssl_cert_real,
+    }
+
+  }
+
+
+  if $mcollective::securityprovider == 'ssl' {
+
+    file { $::mcollective::ssl_server_public_path:
+      owner  => 'root',
+      group  => '0',
+      mode   => '0444',
+      source => $::mcollective::ssl_server_public,
+    }
+
+    file { $::mcollective::ssl_server_private_path:
+      owner  => 'root',
+      group  => '0',
+      mode   => '0400',
+      source => $::mcollective::ssl_server_private,
+    }
+
   }
 
   mcollective::soft_include { [

--- a/manifests/server/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/server/config/connector/activemq/hosts_iteration.pp
@@ -3,11 +3,11 @@
 define mcollective::server::config::connector::activemq::hosts_iteration {
   if $mcollective::middleware_ssl {
     mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.cert":
-      value => "${mcollective::confdir}/server_public.pem",
+      value => $::mcollective::middleware_ssl_cert_path,
     }
 
     mcollective::server::setting { "plugin.activemq.pool.${name}.ssl.key":
-      value => "${mcollective::confdir}/server_private.pem",
+      value => $::mcollective::middleware_ssl_key_path,
     }
   }
 }

--- a/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/server/config/connector/rabbitmq/hosts_iteration.pp
@@ -3,11 +3,11 @@
 define mcollective::server::config::connector::rabbitmq::hosts_iteration {
   if $mcollective::middleware_ssl {
     mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.cert":
-      value => "${mcollective::confdir}/server_public.pem",
+      value => $::mcollective::middleware_ssl_cert_path,
     }
 
     mcollective::server::setting { "plugin.rabbitmq.pool.${name}.ssl.key":
-      value => "${mcollective::confdir}/server_private.pem",
+      value => $::mcollective::middleware_ssl_key_path,
     }
   }
 }

--- a/manifests/server/config/securityprovider/ssl.pp
+++ b/manifests/server/config/securityprovider/ssl.pp
@@ -19,10 +19,10 @@ class mcollective::server::config::securityprovider::ssl {
   }
 
   mcollective::server::setting { 'plugin.ssl_server_public':
-    value => "${mcollective::confdir}/server_public.pem",
+    value => $::mcollective::ssl_server_public_path,
   }
 
   mcollective::server::setting { 'plugin.ssl_server_private':
-    value => "${mcollective::confdir}/server_private.pem",
+    value => $::mcollective::ssl_server_private_path,
   }
 }


### PR DESCRIPTION
The modules mixes middleware ssl and mcollective ssl. 

The middleware ssl (plugin.activemq.pool.1.ssl.{ca,cert,key}) is used for connection encryption. The nodes puppet key/cert can be used.

The mcollective ssl (plugin.ssl_server_{public,private}) is a shared secret among all mcollectiv servers. The nodes puppet key/cert can't be used. The ca.pem isn't used at all for securityprovider=ssl.

The patch moves the key/cert files from /etc/mcollective to /etc/mcollective/ssl/{middleware_key,middleware_cert,middleware_ca,server_public,server_private}.pem and introduces "middleware_ssl_ca" (default: ssl_server_ca) , "middleware_ssl_key" and "middleware_ssl_cert".