### PR TITLE
common/config: Set mode on site_libdir.

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -8,6 +8,7 @@ class mcollective::common::config {
     ensure       => directory,
     owner        => 'root',
     group        => '0',
+    mode         => '0644',
     recurse      => true,
     purge        => true,
     force        => true,

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -45,7 +45,7 @@ describe 'mcollective' do
       it 'should default to installed' do
         should contain_package('ruby-stomp').with_ensure('installed')
       end
-      
+
       context 'latest' do
         let(:params) { { :ruby_stomp_ensure => 'latest' } }
         it { should contain_package('ruby-stomp').with_ensure('latest') }
@@ -138,7 +138,7 @@ describe 'mcollective' do
             end
             it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/etc\/mcollective\/facts.yaml.new', '\/etc\/mcollective\/facts.yaml'\)/) }
           end
-          
+
           context '/tmp/facts' do
             let(:params) { { :yaml_fact_path => '/tmp/facts' } }
             it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
@@ -359,7 +359,7 @@ describe 'mcollective' do
 
     describe '#site_libdir' do
       context 'default' do
-        it { should contain_file('/usr/local/libexec/mcollective') }
+        it { should contain_file('/usr/local/libexec/mcollective').with_mode('0644') }
         it { should contain_mcollective__common__setting('libdir').with_value('/usr/local/libexec/mcollective:/usr/libexec/mcollective') }
       end
 


### PR DESCRIPTION
Currently we're not setting a mode in `$site_libdi`r which basically means
we get whatever Puppet decides it should be.

On our systems this suddenly turned `$site_libdir` to '0770' meaning users
could not longer read/load/initialise plugins that were installed.

By explicitly setting it to '0644' we get the desired behaviour,
everyone can walk the path and read the files but only root can update
them.