### PR TITLE
Fix cron definition for Solaris.

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -17,8 +17,7 @@ class mcollective::server::config::factsource::yaml {
     before  => Cron['refresh-mcollective-metadata'],
   }
   cron { 'refresh-mcollective-metadata':
-    environment => "PATH=/opt/puppet/bin:${::path}",
-    command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
+    command     => "PATH=/opt/puppet/bin:${::path} ${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }


### PR DESCRIPTION
Solaris' cron doesn't support setting environment variables on separate lines, and Puppet doesn't handle this at all so it fails unceremoniously. 

Prepending the command with the PATH has the same effect and works everywhere.

Tested on Solaris 11.2.