### PR TITLE
Make the ruby interpreter used in the script for the cron job configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ internally: `uptime.*`, `rubysitedir`, `_timestamp`, `memoryfree.*`,
 `swapfree.*` and `last_run`. Note that the fact names can be Ruby regular
 expressions.
 
+##### `ruby_interpreter`
+
+String: defaults to '/usr/bin/env ruby'. With `factsource` 'yaml', a ruby
+script gets installed as cron job, that needs to find the ruby interpreter.
+This parameter allows overriding the default interpreter.
+
 ##### `classesfile`
 
 String: defaults to '/var/lib/puppet/state/classes.txt'.  Name of the file the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class mcollective (
   $service_name       = 'mcollective',
   $server_package     = 'mcollective',
   $ruby_stomp_package = 'ruby-stomp',
+  $ruby_interpreter   = '/usr/bin/env ruby',
 
   # client-specific
   $client_config_file  = undef, # default dependent on $confdir

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,6 +6,7 @@ class mcollective::server::config::factsource::yaml {
 
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
+  $ruby_interpreter    = $mcollective::ruby_interpreter
 
   # Template uses:
   #   - $yaml_fact_path_real

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -144,6 +144,13 @@ describe 'mcollective' do
             it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
             it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
           end
+          context 'ruby_interpreter default' do
+            it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/^#!\/usr\/bin\/env ruby$/) }
+          end
+          context 'ruby_interpreter non-default' do
+            let(:params) { { :ruby_interpreter => '/usr/local/bin/ruby21' } }
+            it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/^#!\/usr\/local\/bin\/ruby21$/) }
+          end
         end
       end
 

--- a/templates/refresh-mcollective-metadata.erb
+++ b/templates/refresh-mcollective-metadata.erb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!<%= @ruby_interpreter %>
 require 'rubygems'
 require 'facter'
 require 'facter/application'


### PR DESCRIPTION
This is done by adding a new variable to init.pp, pre-configured with the current value in params.pp, so, current behaviour doesn't change. It only adds the possibility to override the location of the ruby interpreter.

It's that in OpenBSD for example, the ruby interpreter is named like ruby21, ruby20, ... etc. based on the version of ruby it is for, in order to ease installation of multiple ruby versions.
For that reason, the default '/usr/bin/env ruby' doesn't work out of the box on OpenBSD.

This is one of a bunch of steps to make the mcollective module support OpenBSD.

Documentation added to README.md, and two new spec regression tests added to the class test, testing the default and custom value of the new parameter.
