### PR TITLE
fix SSL port selectors when middleware_ssl is passed in from Hiera.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
       ref: '0.5.0'
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.2.0'
   symlinks:
     mcollective: '#{source_dir}'

--- a/manifests/common/config/connector/activemq/hosts_iteration.pp
+++ b/manifests/common/config/connector/activemq/hosts_iteration.pp
@@ -6,7 +6,12 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     value => $middleware_hosts_array[$name - 1],
   }
 
-  $port = $mcollective::middleware_ssl ? {
+  $middleware_ssl = is_bool($mcollective::middleware_ssl) ? {
+    true  => $mcollective::middleware_ssl,
+    false => str2bool($mcollective::middleware_ssl),
+  }
+
+  $port = $middleware_ssl ? {
     true    => $mcollective::middleware_ssl_port,
     default => $mcollective::middleware_port,
   }
@@ -28,7 +33,7 @@ define mcollective::common::config::connector::activemq::hosts_iteration {
     value => $mcollective::middleware_password,
   }
 
-  if $mcollective::middleware_ssl {
+  if $middleware_ssl {
     mcollective::common::setting { "plugin.activemq.pool.${name}.ssl":
       value => 1,
     }

--- a/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
+++ b/manifests/common/config/connector/rabbitmq/hosts_iteration.pp
@@ -5,7 +5,12 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     value => $mcollective::middleware_hosts[$name - 1], # puppet array 0-based
   }
 
-  $port = $mcollective::middleware_ssl ? {
+  $middleware_ssl = is_bool($mcollective::middleware_ssl) ? {
+    true  => $mcollective::middleware_ssl,
+    false => str2bool($mcollective::middleware_ssl),
+  }
+
+  $port = $middleware_ssl ? {
     true    => $mcollective::middleware_ssl_port,
     default => $mcollective::middleware_port,
   }
@@ -22,7 +27,7 @@ define mcollective::common::config::connector::rabbitmq::hosts_iteration {
     value => $mcollective::middleware_password,
   }
 
-  if $mcollective::middleware_ssl {
+  if $middleware_ssl {
     mcollective::common::setting { "plugin.rabbitmq.pool.${name}.ssl":
       value => 1,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0"
+      "version_requirement": ">=4.2.0"
     }
   ]
 }


### PR DESCRIPTION
Hi,

this caused me some grey hair for quite a while, and I am not sure, 
this might also be a bug in Hiera, anyways ;)

I have this in my hiera:
/etc/puppet/hieradata# grep -r middleware_ssl *
global.yaml:site_mcollective::params::middleware_ssl: "%{hiera('role::networkmanagement::puppetmaster::mcollective::middleware_ssl')}"
production/default.yaml:role::networkmanagement::puppetmaster::mcollective::middleware_ssl: true
The selectors deciding whether to use SSL or Non-SSL ports,
work with this change when middleware_ssl parameter value
is passed in from Hiera.

So the value for middleware_ssl is defined as true in the production/default.yaml, and then recursively
looked up in the global.yaml file.

Similar to the examples directory, I do have an umbrella module, that is picking up 
site_mcollective::params::middleware_ssl
via automatic parameter lookup, and then passing that value to the mcollective class.

So far, so good, now my grey hair:

in manifests/common/config/connector/activemq/hosts_iteration.pp
I had:
  $port = $mcollective::middleware_ssl ? {
    true    => $mcollective::middleware_ssl_port,
    default => $mcollective::middleware_port,
  }

notify {"got this as middleware_ssl: $mcollective::middleware_ssl SSL port: $mcollective::middleware_ssl_port normal port: $mcollective::middleware_port , RESULT: port: $port":}

and I got:

Notice: got this as middleware_ssl: true SSL port: 61614 normal port: 61613 , RESULT: port: 61613
Notice: /Stage[main]/Mcollective::Common::Config::Connector::Activemq/Mcollective::Common::Config::Connector::Activemq::Hosts_iteration[1]/Notify[got this as middleware_ssl: true SSL port: 61614 normal port: 61613 , RESULT: port: 61613]/message: defined 'message' as 'got this as middleware_ssl: true SSL port: 61614 normal port: 61613 , RESULT: port: 61613'

This helped me to deduce, that the 'true' value defined in Hiera ended up as a string, but the plain true
in the selector did not matched it.

so what I do now is to use a local middleware_ssl variable, ensuring that it definately is a bool variable.
Have only tested with activemq, but since the very same pattern is in the rabbitmq hosts_iteration.pp, i made the same change there too.

However, to make the regress tests pass, I had to upgrade the minimal required stdlib version in .fixtures.yaml and metadata.json. Looking at the stdlib compatibility matrix with Puppet versions, it should not really make a difference:
https://forge.puppetlabs.com/puppetlabs/stdlib#limitations

Is this a way to go for you? If not, I can also just add the very same logic into my umbrella mcollective
module.

My environment is OpenBSD, 5.7-beta, Puppet 3.7.4, Ruby-2.1.5, Hiera-1.3.4. But as said,
I'm not 100% sure, this is a problem of the module, or of Hiera or Puppet.


