### PR TITLE
Ensure that the core_libdir is present.

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -9,11 +9,18 @@ class mcollective::server::config::factsource::yaml {
 
   # Template uses:
   #   - $yaml_fact_path_real
+  file { "${mcollective::core_libdir}":
+    ensure  => 'directory',
+    owner   => '0',
+    group   => '0',
+    mode    => '0755',
+  }
   file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
     owner   => '0',
     group   => '0',
     mode    => '0755',
     content => template('mcollective/refresh-mcollective-metadata.erb'),
+    require => File["${mcollective::core_libdir}"],
     before  => Cron['refresh-mcollective-metadata'],
   }
   cron { 'refresh-mcollective-metadata':


### PR DESCRIPTION
On a fresh Ubuntu 12.04 install I was not able to install mcollective with this module but instead got this error message:

```
Notice: /Stage[main]/Mcollective/Mcollective::Server/Mcollective::Server::Install/Package[mcollective]/ensure: ensure changed 'purged' to 'present'
Error: Could not set 'file' on ensure: No such file or directory - /usr/share/mcollective/plugins/refresh-mcollective-metadata20150311-7289-wq2uox.lock at 18:/etc/puppet/modules/mcollective/manifests/server/config/factsource/yaml.pp
Error: Could not set 'file' on ensure: No such file or directory - /usr/share/mcollective/plugins/refresh-mcollective-metadata20150311-7289-wq2uox.lock at 18:/etc/puppet/modules/mcollective/manifests/server/config/factsource/yaml.pp
Wrapped exception:
No such file or directory - /usr/share/mcollective/plugins/refresh-mcollective-metadata20150311-7289-wq2uox.lock
Error: /Stage[main]/Mcollective::Server::Config::Factsource::Yaml/File[/usr/share/mcollective/plugins/refresh-mcollective-metadata]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /usr/share/mcollective/plugins/refresh-mcollective-metadata20150311-7289-wq2uox.lock at 18:/etc/puppet/modules/mcollective/manifests/server/config/factsource/yaml.pp
Notice: /Stage[main]/Mcollective::Server::Config::Factsource::Yaml/Cron[refresh-mcollective-metadata]: Dependency File[/usr/share/mcollective/plugins/refresh-mcollective-metadata] has failures: true
Warning: /Stage[main]/Mcollective::Server::Config::Factsource::Yaml/Cron[refresh-mcollective-metadata]: Skipping because of failed dependencies
Notice: /Stage[main]/Mcollective::Server::Config::Factsource::Yaml/Exec[create-mcollective-metadata]: Dependency File[/usr/share/mcollective/plugins/refresh-mcollective-metadata] has failures: true
Warning: /Stage[main]/Mcollective::Server::Config::Factsource::Yaml/Exec[create-mcollective-metadata]: Skipping because of failed dependencies
```