### PR TITLE
prepare 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
+2015-03-31 Release 2.1.0
+========================
+
+Summary:
+
+This release comes with no big changes since 2.0.0. The biggest news is that
+we've moved to the "puppet" namespace on the forge, and the puppet-community
+space on GitHub.
+
+Bugfixes:
+- fix propagation of middleware\_ssl\_fallback for rabbitmq
+- Use string for host\_iteration titles in future parser ([MODULES-773](https://tickets.puppetlabs.com/browse/MODULES-773)
+
+
 2014-09-03 Release 2.0.0
+========================
+
 Summary:
 
 This is a fairly large rewrite of many parts of the mcollective module to
@@ -10,16 +26,16 @@ Backwards-incompatible Features:
 - Removed the management of activemq and rabbitmq
 - Removed the following parameters:
   - mcollective::middleware
-  - mcollective::activemq_template
-	- mcollective::activemq_memoryUsage
-	- mcollective::activemq_storeUsage
-	- mcollective::activemq_tempUsage
-	- mcollective::activemq_console
-	- mcollective::activemq_config
-	- mcollective::activemq_confdir
-	- mcollective::rabbitmq_confdir
-	- mcollective::rabbitmq_vhost
-	- mcollective::delete_guest_user
+  - mcollective::activemq\_template
+	- mcollective::activemq\_memoryUsage
+	- mcollective::activemq\_storeUsage
+	- mcollective::activemq\_tempUsage
+	- mcollective::activemq\_console
+	- mcollective::activemq\_config
+	- mcollective::activemq\_confdir
+	- mcollective::rabbitmq\_confdir
+	- mcollective::rabbitmq\_vhost
+	- mcollective::delete\_guest\_user
 
 Features:
 - Make the confdir configurable
@@ -27,20 +43,21 @@ Features:
 - Replace facts.yaml pattern with cron job
 - Allow mcollective::collectives to be an array
 - Added the following parameters to class mcollective:
-  - client_package
+  - client\_package
 	- confdir
-	- rabbitmq_vhost
-	- service_name
-	- server_package
-	- ruby_stomp_package
-	- ssl_client_certs_dir
+	- rabbitmq\_vhost
+	- service\_name
+	- server\_package
+	- ruby\_stomp\_package
+	- ssl\_client\_certs\_dir
 
 Bugfixes:
-- Honor yaml_fact_path parameter in all the relevant places
-- Use string for host_iteration titles in future parser, as integers are not
+- Honor yaml\_fact\_path parameter in all the relevant places
+- Use string for host\_iteration titles in future parser, as integers are not
 allowed as titles
 
 2014-07-15 Release 1.1.6
+========================
 
 Summary:
 
@@ -49,6 +66,7 @@ upgraded via the puppet module command, as well as fixes a documentation
 typo.
 
 2014-06-06 Release 1.1.5
+========================
 
 Summary:
 
@@ -58,19 +76,21 @@ Fixes:
 - Remove deprecated Modulefile as it was causing duplicate dependencies with PMT.
 
 2014-06-04 Release 1.1.4
+========================
 
 Summary:
 
 This is a feature release that adds a number of new parameters.
 
 Features:
-- Add support for $activemq_memoryUsage, $activemq_storeUsage 
-  and $activemq_tempUsage
-- Add $ruby_stomp_ensure for manage ruby-stomp package
-- Add support for $excluded_facts
-- Add support for $$middleware_ssl_fallback
+- Add support for $activemq\_memoryUsage, $activemq\_storeUsage
+  and $activemq\_tempUsage
+- Add $ruby\_stomp\_ensure for manage ruby-stomp package
+- Add support for $excluded\_facts
+- Add support for $$middleware\_ssl\_fallback
 
 2013-11-13 Release 1.1.3
+========================
 
 Summary:
 
@@ -78,25 +98,28 @@ STOP IT PUPPET STOP. We've now fixed the problem for REAL, it was a missing
 source and author field in the Modulefile.
 
 2013-11-12 Release 1.1.2
+========================
 
 Summary:
 
 Metadata.json is persistent and made it into the tarball.
 
 2013-10-21 Release 1.1.1
+========================
 
 Summary:
 
 This is a bugfix release, primarily to remove metadata.json, as it seems to
-cause errors for some users.  Also exclude last_run from the facts, and grant
+cause errors for some users.  Also exclude last\_run from the facts, and grant
 rabbitmq's admin user configure permissions.
 
 Fixes:
 - Remove metadata.json
 - Grant the rabbitmq admin user configure permissions.
-- Add last_run to the list of dynamic facts that are filtered out.
+- Add last\_run to the list of dynamic facts that are filtered out.
 
 2013-10-11 Release 1.1.0
+========================
 
 Summary:
 
@@ -107,14 +130,15 @@ the middleware appropriately.  The README has been updated with further
 information.
 
 Features:
-- Add $delete_guest_user functionality.
-- Add middleware_admin_user and middleware_admin_password parameters.
+- Add $delete\_guest\_user functionality.
+- Add middleware\_admin\_user and middleware\_admin\_password parameters.
 - Don't supply a client.cfg when securityprovider is 'ssl'
 
 Fixes:
 - Use hash to build anonymous hash (in order to not require future parser)
 
 2013-10-03 Release 1.0.1
+========================
 
 Summary:
 
@@ -128,6 +152,7 @@ Fixes:
 
 
 2013-09-27 Release 1.0.0
+========================
 
 Summary:
 The initial stable release of the mcollective module.

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :travis_release => [
 desc "Check Changelog."
 task :check_changelog do
   v = Blacksmith::Modulefile.new.version
-  if File.readlines('CHANGELOG.md').grep("Releasing #{v}").size == 0 then
+  if File.readlines('CHANGELOG.md').grep("Release #{v}").size == 0 then
     fail "Unable to find a CHANGELOG.md entry for the #{v} release."
   end
 end


### PR DESCRIPTION
* move CHANGELOG to markdown format.
* add changes from this release
* adapt rakefile to check for the format we've had in CHANGELOG so far
  (Release 2.1.0, rather than Releasing 2.1.0)