### PR TITLE
Don't attempt to drop files in non-existent paths

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -9,7 +9,7 @@ class mcollective::server::config::factsource::yaml {
 
   # Template uses:
   #   - $yaml_fact_path_real
-  file { "${mcollective::core_libdir}/refresh-mcollective-metadata":
+  file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
     owner   => '0',
     group   => '0',
     mode    => '0755',
@@ -18,15 +18,15 @@ class mcollective::server::config::factsource::yaml {
   }
   cron { 'refresh-mcollective-metadata':
     environment => "PATH=/opt/puppet/bin:${::path}",
-    command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
+    command     => "${mcollective::site_libdir}/refresh-mcollective-metadata",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",
-    command => "${mcollective::core_libdir}/refresh-mcollective-metadata",
+    command => "${mcollective::site_libdir}/refresh-mcollective-metadata",
     creates => $yaml_fact_path_real,
-    require => File["${mcollective::core_libdir}/refresh-mcollective-metadata"],
+    require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
   }
 
   mcollective::server::setting { 'factsource':

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -136,13 +136,13 @@ describe 'mcollective' do
             it 'should default to /etc/mcollective/facts.yaml' do
               should contain_mcollective__server__setting('plugin.yaml').with_value('/etc/mcollective/facts.yaml')
             end
-            it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/etc\/mcollective\/facts.yaml.new', '\/etc\/mcollective\/facts.yaml'\)/) }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/etc\/mcollective\/facts.yaml.new', '\/etc\/mcollective\/facts.yaml'\)/) }
           end
           
           context '/tmp/facts' do
             let(:params) { { :yaml_fact_path => '/tmp/facts' } }
             it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
-            it { should contain_file('/usr/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
           end
         end
       end


### PR DESCRIPTION
In MCollective 2.8 the packages no longer put files into core_libdir
(MCO-583, MCO-315), which makes these file resources fail as the
parent directory is never created but is assumed to be created by
the package install.

`refresh-mcollective-metadata` should never have been put into
core_libdir to begin with as that's intended to be space owned by
native OS packages.   It's doubly inappropriate as it's not a
loadable ruby file for an MCollective extension, it's a helper
executable for this module.

Here we just put it in $site_libdir, as that is a directory that
this module creates and populates.