### PR TITLE
fix issue #213 by silencing refresh-mcollective-metadata cronjob

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -18,7 +18,7 @@ class mcollective::server::config::factsource::yaml {
   }
   cron { 'refresh-mcollective-metadata':
     environment => "PATH=/opt/puppet/bin:${::path}",
-    command     => "${mcollective::site_libdir}/refresh-mcollective-metadata",
+    command     => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
     user        => 'root',
     minute      => [ '0', '15', '30', '45' ],
   }


### PR DESCRIPTION
See https://github.com/puppet-community/puppet-mcollective/issues/213 - the cronjob just often spams without any meaning because interfaces may appear and disappear at will on many systems and facter is not smart enough about it:


https://projects.puppetlabs.com/issues/15035
https://projects.puppetlabs.com/issues/15798