### PR TITLE
Remove environment parameter from cron resource

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,8 +6,13 @@ class mcollective::server::config::factsource::yaml {
 
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
+  $ruby_shebang_path   = $::is_pe ? {
+    true    => '/opt/puppet/bin/ruby',
+    default => '/usr/bin/env ruby',
+  }
 
   # Template uses:
+  #   - $ruby_shebang_path
   #   - $yaml_fact_path_real
   file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
     owner   => '0',
@@ -17,10 +22,9 @@ class mcollective::server::config::factsource::yaml {
     before  => Cron['refresh-mcollective-metadata'],
   }
   cron { 'refresh-mcollective-metadata':
-    environment => "PATH=/opt/puppet/bin:${::path}",
-    command     => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
-    user        => 'root',
-    minute      => [ '0', '15', '30', '45' ],
+    command => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
+    user    => 'root',
+    minute  => [ '0', '15', '30', '45' ],
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",

--- a/templates/refresh-mcollective-metadata.erb
+++ b/templates/refresh-mcollective-metadata.erb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!<%= @ruby_shebang_path %>
 require 'rubygems'
 require 'facter'
 require 'facter/application'


### PR DESCRIPTION
Crontab environment variables are global and we do not as a matter of
best practice want to leak environment variables into other cron jobs.
We still want to ensure the correct ruby is used to instantiate the
refresh-mcollective-metadata script but we can accomplish this by
templatizing the shebang line rather than relying on environment
variables in the crontab.

Closes #207