### PR TITLE
Support the C-based facter 3.x with a better cronjob

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ server.
 String: defaults to '/etc/mcollective/facts.yaml'.  Name of the file the
 'yaml' factsource plugin should load facts from.
 
+##### `puppet_exec_path`
+
+String: defaults to '/opt/puppetlabs/puppet/bin'.  If you're using Facter 3.x
+the 'yaml' factsource plugin will search for `puppet` in this dir.
+
 ##### `excluded_facts`
 Array: defaults to []. List of facts to exclude from facts.yaml when
 `factsource` is 'yaml'. This is useful for preventing dynamic facts (that

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ class mcollective (
   $factsource       = 'yaml',
   $yaml_fact_path   = undef,
   $yaml_fact_cron   = true,
+  $puppet_exec_path = '/opt/puppetlabs/puppet/bin', # only for Facter 3+ / Puppet 4.2+
   $excluded_facts   = [],
   $classesfile      = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider  = 'action_policy',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -12,22 +12,25 @@ class mcollective::server::config::factsource::yaml {
   }
   $yaml_fact_cron      = $mcollective::yaml_fact_cron
 
-  # Template uses:
-  #   - $ruby_shebang_path
-  #   - $yaml_fact_path_real
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        command => "${mcollective::puppet_exec_path}/puppet facts --render-as --yaml >${yaml_fact_path_real} 2>&1",
         user    => 'root',
         minute  => [ '0', '15', '30', '45' ],
       }
       exec { 'create-mcollective-metadata':
         path    => "/opt/puppet/bin:${::path}",
-        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        command => "${mcollective::puppet_exec_path}/puppet facts --render-as --yaml >${yaml_fact_path_real} 2>&1",
         creates => $yaml_fact_path_real,
       }
+      mcollective::server::setting { 'puppet_exec_path':
+        value => "${mcollective::puppet_exec_path}/puppet",
+      }
     } else {
+      # Template uses:
+      #   - $ruby_shebang_path
+      #   - $yaml_fact_path_real
       file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
         owner   => '0',
         group   => '0',

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -18,13 +18,13 @@ class mcollective::server::config::factsource::yaml {
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command => "facter >${yaml_fact_path_real} 2>&1",
+        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
         user    => 'root',
         minute  => [ '0', '15', '30', '45' ],
       }
       exec { 'create-mcollective-metadata':
         path    => "/opt/puppet/bin:${::path}",
-        command => "facter >${yaml_fact_path_real} 2>&1",
+        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
         creates => $yaml_fact_path_real,
       }
     } else {

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -15,32 +15,43 @@ class mcollective::server::config::factsource::yaml {
   # Template uses:
   #   - $ruby_shebang_path
   #   - $yaml_fact_path_real
-  file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
-    owner   => '0',
-    group   => '0',
-    mode    => '0755',
-    content => template('mcollective/refresh-mcollective-metadata.erb'),
-  }
   if $yaml_fact_cron {
-    cron { 'refresh-mcollective-metadata':
-      command => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
-      user    => 'root',
-      minute  => [ '0', '15', '30', '45' ],
-      require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+    if versioncmp($::facterversion, '3.0.0') >= 0 {
+      cron { 'refresh-mcollective-metadata':
+        command => "facter >${yaml_fact_path_real} 2>&1",
+        user    => 'root',
+        minute  => [ '0', '15', '30', '45' ],
+      }
+      exec { 'create-mcollective-metadata':
+        path    => "/opt/puppet/bin:${::path}",
+        command => "facter >${yaml_fact_path_real} 2>&1",
+        creates => $yaml_fact_path_real,
+      }
+    } else {
+      file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
+        owner   => '0',
+        group   => '0',
+        mode    => '0755',
+        content => template('mcollective/refresh-mcollective-metadata.erb'),
+      }
+      cron { 'refresh-mcollective-metadata':
+        command => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
+        user    => 'root',
+        minute  => [ '0', '15', '30', '45' ],
+        require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+      }
+      exec { 'create-mcollective-metadata':
+        path    => "/opt/puppet/bin:${::path}",
+        command => "${mcollective::site_libdir}/refresh-mcollective-metadata",
+        creates => $yaml_fact_path_real,
+        require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+      }
     }
-  }
-  exec { 'create-mcollective-metadata':
-    path    => "/opt/puppet/bin:${::path}",
-    command => "${mcollective::site_libdir}/refresh-mcollective-metadata",
-    creates => $yaml_fact_path_real,
-    require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
-  }
-
-  mcollective::server::setting { 'factsource':
-    value => 'yaml',
-  }
-
-  mcollective::server::setting { 'plugin.yaml':
-    value => $yaml_fact_path_real,
+    mcollective::server::setting { 'factsource':
+      value => 'yaml',
+    }
+    mcollective::server::setting { 'plugin.yaml':
+      value => $yaml_fact_path_real,
+    }
   }
 }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -128,8 +128,8 @@ describe 'mcollective' do
         should contain_mcollective__server__setting('factsource').with_value('yaml')
       end
 
-      context 'yaml' do
-        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69 } }
+      context 'yaml_facter2' do
+        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4' } }
 
         describe '#yaml_fact_path' do
           context 'default' do
@@ -143,6 +143,36 @@ describe 'mcollective' do
             let(:params) { { :yaml_fact_path => '/tmp/facts' } }
             it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
             it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
+          end
+        end
+
+        describe '#yaml_fact_cron' do
+          context 'default (true)' do
+            it { should contain_cron('refresh-mcollective-metadata') }
+          end
+
+          context 'false' do
+            let(:params) { { :yaml_fact_cron => false } }
+            it { should_not contain_cron('refresh-mcollective-metadata') }
+          end
+        end
+      end
+
+      context 'yaml_facter3' do
+        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '3.0.1' } }
+
+        describe '#yaml_fact_path' do
+          context 'default' do
+            it 'should default to /etc/mcollective/facts.yaml' do
+              should contain_mcollective__server__setting('plugin.yaml').with_value('/etc/mcollective/facts.yaml')
+            end
+            it { should_not contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata') }
+          end
+
+          context '/tmp/facts' do
+            let(:params) { { :yaml_fact_path => '/tmp/facts' } }
+            it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
+            it { should_not contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata') }
           end
         end
 

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -176,6 +176,21 @@ describe 'mcollective' do
           end
         end
 
+        describe '#puppet_exec_path' do
+          context 'default' do
+            it 'should default to /opt/puppetlabs/puppet/bin/puppet' do
+              should contain_mcollective__server__setting('puppet_exec_path').with_value('/opt/puppetlabs/puppet/bin/puppet')
+            end
+          end
+
+          context '/some/path/to/puppet' do
+            let(:params) { { :puppet_exec_path => '/some/path/to/puppet' } }
+            it 'should be /some/path/to/puppet/puppet' do
+              should contain_mcollective__server__setting('puppet_exec_path').with_value('/some/path/to/puppet/puppet')
+            end
+          end
+        end
+
         describe '#yaml_fact_cron' do
           context 'default (true)' do
             it { should contain_cron('refresh-mcollective-metadata') }


### PR DESCRIPTION
For `$::facterversion >= 3.0.0` we should not use the Ruby-based `refresh-mcollective-metadata` but instead just run `facter --yaml` as the old Ruby support is gone.

Includes new rake spec tests - all passing.

