### PR TITLE
Fix facts with facter3

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -15,32 +15,43 @@ class mcollective::server::config::factsource::yaml {
   # Template uses:
   #   - $ruby_shebang_path
   #   - $yaml_fact_path_real
-  file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
-    owner   => '0',
-    group   => '0',
-    mode    => '0755',
-    content => template('mcollective/refresh-mcollective-metadata.erb'),
-  }
   if $yaml_fact_cron {
-    cron { 'refresh-mcollective-metadata':
-      command => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
-      user    => 'root',
-      minute  => [ '0', '15', '30', '45' ],
-      require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+    if versioncmp($::facterversion, '3.0.0') >= 0 {
+      cron { 'refresh-mcollective-metadata':
+        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        user    => 'root',
+        minute  => [ '0', '15', '30', '45' ],
+      }
+      exec { 'create-mcollective-metadata':
+        path    => "/opt/puppet/bin:${::path}",
+        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        creates => $yaml_fact_path_real,
+      }
+    } else {
+      file { "${mcollective::site_libdir}/refresh-mcollective-metadata":
+        owner   => '0',
+        group   => '0',
+        mode    => '0755',
+        content => template('mcollective/refresh-mcollective-metadata.erb'),
+      }
+      cron { 'refresh-mcollective-metadata':
+        command => "${mcollective::site_libdir}/refresh-mcollective-metadata >/dev/null 2>&1",
+        user    => 'root',
+        minute  => [ '0', '15', '30', '45' ],
+        require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+      }
+      exec { 'create-mcollective-metadata':
+        path    => "/opt/puppet/bin:${::path}",
+        command => "${mcollective::site_libdir}/refresh-mcollective-metadata",
+        creates => $yaml_fact_path_real,
+        require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
+      }
     }
-  }
-  exec { 'create-mcollective-metadata':
-    path    => "/opt/puppet/bin:${::path}",
-    command => "${mcollective::site_libdir}/refresh-mcollective-metadata",
-    creates => $yaml_fact_path_real,
-    require => File["${mcollective::site_libdir}/refresh-mcollective-metadata"],
-  }
-
-  mcollective::server::setting { 'factsource':
-    value => 'yaml',
-  }
-
-  mcollective::server::setting { 'plugin.yaml':
-    value => $yaml_fact_path_real,
+    mcollective::server::setting { 'factsource':
+      value => 'yaml',
+    }
+    mcollective::server::setting { 'plugin.yaml':
+      value => $yaml_fact_path_real,
+    }
   }
 }

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -18,12 +18,13 @@ class mcollective::server::config::factsource::yaml {
   if $yaml_fact_cron {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
-        command => "facter --yaml >${yaml_fact_path_real} 2>&1",
-        user    => 'root',
-        minute  => [ '0', '15', '30', '45' ],
+        command     => "facter --yaml >${yaml_fact_path_real} 2>&1",
+        environment => "PATH=/opt/puppet/bin:/opt/puppetlabs/bin:${::path}",
+        user        => 'root',
+        minute      => [ '0', '15', '30', '45' ],
       }
       exec { 'create-mcollective-metadata':
-        path    => "/opt/puppet/bin:${::path}",
+        path    => "/opt/puppet/bin:/opt/puppetlabs/bin:${::path}",
         command => "facter --yaml >${yaml_fact_path_real} 2>&1",
         creates => $yaml_fact_path_real,
       }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -128,8 +128,8 @@ describe 'mcollective' do
         should contain_mcollective__server__setting('factsource').with_value('yaml')
       end
 
-      context 'yaml' do
-        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69 } }
+      context 'yaml_facter2' do
+        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4' } }
 
         describe '#yaml_fact_path' do
           context 'default' do
@@ -143,6 +143,36 @@ describe 'mcollective' do
             let(:params) { { :yaml_fact_path => '/tmp/facts' } }
             it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
             it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(/File.rename\('\/tmp\/facts.new', '\/tmp\/facts'\)/) }
+          end
+        end
+
+        describe '#yaml_fact_cron' do
+          context 'default (true)' do
+            it { should contain_cron('refresh-mcollective-metadata') }
+          end
+
+          context 'false' do
+            let(:params) { { :yaml_fact_cron => false } }
+            it { should_not contain_cron('refresh-mcollective-metadata') }
+          end
+        end
+      end
+
+      context 'yaml_facter3' do
+        let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '3.0.1' } }
+
+        describe '#yaml_fact_path' do
+          context 'default' do
+            it 'should default to /etc/mcollective/facts.yaml' do
+              should contain_mcollective__server__setting('plugin.yaml').with_value('/etc/mcollective/facts.yaml')
+            end
+            it { should_not contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata') }
+          end
+
+          context '/tmp/facts' do
+            let(:params) { { :yaml_fact_path => '/tmp/facts' } }
+            it { should contain_mcollective__server__setting('plugin.yaml').with_value('/tmp/facts') }
+            it { should_not contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata') }
           end
         end
 


### PR DESCRIPTION
facter3 generates yaml facts itself - we should use that functionality.

This supercedes https://github.com/puppet-community/puppet-mcollective/pull/225

Tested with `puppet-agent-1.2.2-1.el7.x86_64`