### PR TITLE
Disabling daemonize in Ubuntu servers

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -18,4 +18,10 @@ class mcollective::defaults {
     'Debian' => '/usr/local/share/mcollective',
     default  => '/usr/local/libexec/mcollective',
   }
+
+  $server_daemonize = $::operatingsystem ? {
+    'Ubuntu' => '0',
+    default  => '1',
+  }
+
 }

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -19,9 +19,9 @@ class mcollective::defaults {
     default  => '/usr/local/libexec/mcollective',
   }
 
-  $server_daemonize = $::operatingsystem ? {
-    'Ubuntu' => '0',
-    default  => '1',
-  }
+if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '14.10') < 0)
+  { $server_daemonize = '0' }
+  else
+  { $server_daemonize = '1' }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class mcollective (
   $server_config_file = undef, # default dependent on $confdir
   $server_logfile     = '/var/log/mcollective.log',
   $server_loglevel    = 'info',
-  $server_daemonize   = 1,
+  $server_daemonize   = $mcollective::defaults::server_daemonize,
   $service_name       = 'mcollective',
   $server_package     = 'mcollective',
   $ruby_stomp_package = 'ruby-stomp',


### PR DESCRIPTION
As explained in the following bugzilla, it would be ideal for Ubuntu servers to have daemonize =0.

https://tickets.puppetlabs.com/browse/MCO-167