### PR TITLE
hardcode PATH instead of using fact $::path

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -19,7 +19,7 @@ class mcollective::server::config::factsource::yaml {
     if versioncmp($::facterversion, '3.0.0') >= 0 {
       cron { 'refresh-mcollective-metadata':
         command     => "facter --yaml >${yaml_fact_path_real} 2>&1",
-        environment => "PATH=/opt/puppet/bin:/opt/puppetlabs/bin:${::path}",
+        environment => 'PATH=/opt/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
         minute      => [ '0', '15', '30', '45' ],
       }


### PR DESCRIPTION
This fixes an issue we can have when we launch puppet agent from terminal : the current PATH may be different depending on the environment.