### PR TITLE
Added identity parameter so that hosts would export fqdn as identity

### DIFF
--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -55,6 +55,11 @@ class mcollective::common::config {
     value => $mcollective::main_collective,
   }
 
+  mcollective::common::setting { 'identity':
+    value => $mcollective::identity,
+  }
+
+
   mcollective::soft_include { [
     "::mcollective::common::config::connector::${mcollective::connector}",
     "::mcollective::common::config::securityprovider::${mcollective::securityprovider}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class mcollective (
   $registration     = undef,
   $core_libdir      = $mcollective::defaults::core_libdir,
   $site_libdir      = $mcollective::defaults::site_libdir,
+  $identity         = $fqdn,
 
   # networking
   $middleware_hosts          = [],


### PR DESCRIPTION
This is same as following pull request.

Added identity parameter so that hosts would export fqdn as identity.
https://github.com/puppet-community/puppet-mcollective/pull/142

I have cleaned the repo and created a new pull request. Following is the issue,

While using Mcollective with Foreman, if hosts are not exporting fqdn to mcollective, 'puppet run' from foreman would not work, as foreman-proxy uses fqdn for 'mco puppet runonce ' command .

Socket.gethostname is used for finding identity by default and could give just hostname in configurations like following..

~~~
[root@centos ~]# cat /etc/sysconfig/network
NETWORKING=yes
HOSTNAME=centos
DOMAINNAME=ppp.com

1.9.3-p484 :002 > Socket.gethostname
=> "centos"
~~~

Facter is more reliable..

~~~
# facter fqdn
centos.ppp.com
~~~

Hello @hunner ,
As per the update of @ffrank in the previous pull request, you are the right person to look at this. Can you have a look?
