### PR TITLE
Remove the ignored excluded_facts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,6 @@ server.
 String: defaults to '/etc/mcollective/facts.yaml'.  Name of the file the
 'yaml' factsource plugin should load facts from.
 
-##### `excluded_facts`
-Array: defaults to []. List of facts to exclude from facts.yaml when
-`factsource` is 'yaml'. This is useful for preventing dynamic facts (that
-change on each Puppet run) from ending up in facts.yaml, which would trigger
-restarts of Mcollective. A default list of facts to ignore is managed
-internally: `uptime.*`, `rubysitedir`, `_timestamp`, `memoryfree.*`,
-`swapfree.*` and `last_run`. Note that the fact names can be Ruby regular
-expressions.
-
 ##### `classesfile`
 
 String: defaults to '/var/lib/puppet/state/classes.txt'.  Name of the file the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,6 @@ class mcollective (
   $factsource       = 'yaml',
   $yaml_fact_path   = undef,
   $yaml_fact_cron   = true,
-  $excluded_facts   = [],
   $classesfile      = '/var/lib/puppet/state/classes.txt',
   $rpcauthprovider  = 'action_policy',
   $rpcauditprovider = 'logfile',


### PR DESCRIPTION
In commit d7290fc14b the facts generation of
mcollective::server::config::factsource::yaml was changed from a template
evaluation to a external script.  This external script doesn't make use of the
mcollective::excluded_facts parameter, so stop documenting and accepting it.