### PR TITLE
$mcollective::excluded_facts does not exist anymore

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,7 +6,6 @@ class mcollective::server::config::factsource::yaml (
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
   $ruby_shebang_path   = $::is_pe ? {
     true    => '/opt/puppet/bin/ruby',


### PR DESCRIPTION
$mcollective::excluded_facts has been remove by https://github.com/puppet-community/puppet-mcollective/commit/512630dfc8b3f979743c1a463b4e8f610299ed20 thus this line fails when using `strict_variables`.