### PR TITLE
Ignore all modules in fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 Gemfile.lock
 spec/fixtures/manifests/site.pp
-spec/fixtures/modules/activemq
-spec/fixtures/modules/datacat
-spec/fixtures/modules/erlang
-spec/fixtures/modules/java_ks
-spec/fixtures/modules/mcollective
-spec/fixtures/modules/rabbitmq
-spec/fixtures/modules/stdlib
+spec/fixtures/modules/*
 .ruby-version
 .ruby-gemset
 .rspec_system


### PR DESCRIPTION
Rather than specifying each module individually, which is silly