### PR TITLE
Adding options for the rpc audit provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,9 @@ class mcollective (
   $ssl_server_private   = undef,
   $ssl_client_certs     = 'puppet:///modules/mcollective/empty',
   $ssl_client_certs_dir = undef, # default dependent on $confdir
+
+  # Action policy settings
+  $allowunconfigured    = '1',
 ) inherits mcollective::defaults {
 
   # Because the correct default value for several parameters is based on another

--- a/manifests/server/config/rpcauthprovider/action_policy.pp
+++ b/manifests/server/config/rpcauthprovider/action_policy.pp
@@ -15,6 +15,6 @@ class mcollective::server::config::rpcauthprovider::action_policy {
   }
 
   mcollective::server::setting { 'plugin.actionpolicy.allow_unconfigured':
-    value => 1,
+    value => $mcollective::allowunconfigured,
   }
 }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -392,6 +392,11 @@ describe 'mcollective' do
         let(:params) { { :server => true, :rpcauthprovider => 'action_policy' } }
         it { should contain_mcollective__server__setting('plugin.actionpolicy.allow_unconfigured').with_value('1') }
       end
+
+      context 'allow_unconfigured' do
+        let(:params) { { :server => true, :rpcauthprovider => 'action_policy', :allowunconfigured => '0' }}
+        it { should contain_mcollective__server__setting('plugin.actionpolicy.allow_unconfigured').with_value('0') }
+      end
     end
 
     describe '#rpcauditprovider' do


### PR DESCRIPTION
It's currently defaulting to 1, which means it's insecure by default.
I've set it to 1 by default, but at least now it can be overriden.

Tests included