### PR TITLE
Show diff option

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,12 @@ String: defaults to 'puppet:///modules/mcollective/empty'.  A file source that
 contains a directory of user certificates which are used by the ssl security
 provider in authenticating user requests.
 
+#### `show_diff`
+
+Boolean: defaults to true. Determines whether puppet will show a diff when
+changing file resources using datacat. Useful for secure environments where
+passwords can't be seen in reports and logs.
+
 ### `mcollective::user` defined type
 
 `mcollective::user` installs a client configuration and any needed client

--- a/manifests/actionpolicy.pp
+++ b/manifests/actionpolicy.pp
@@ -4,11 +4,12 @@
 # Namevar will be the name of the agent to configure
 define mcollective::actionpolicy($default = 'deny') {
   datacat { "mcollective::actionpolicy ${name}":
-    owner    => 'root',
-    group    => '0',
-    mode     => '0400',
-    path     => "${mcollective::confdir}/policies/${name}.policy",
-    template => 'mcollective/actionpolicy.erb',
+    owner     => 'root',
+    group     => '0',
+    mode      => '0400',
+    path      => "${mcollective::confdir}/policies/${name}.policy",
+    template  => 'mcollective/actionpolicy.erb',
+    show_diff => $mcollective::show_diff,
   }
 
   datacat_fragment { "mcollective::actionpolicy ${name} actionpolicy default":

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -14,11 +14,12 @@ class mcollective::client::config {
   }
   else {
     datacat { 'mcollective::client':
-      owner    => 'root',
-      group    => '0',
-      mode     => '0444',
-      path     => $mcollective::client_config_file_real,
-      template => 'mcollective/settings.cfg.erb',
+      owner     => 'root',
+      group     => '0',
+      mode      => '0444',
+      path      => $mcollective::client_config_file_real,
+      template  => 'mcollective/settings.cfg.erb',
+      show_diff => $mcollective::show_diff,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,11 @@ class mcollective (
   $ssl_server_public    = undef,
   $ssl_server_private   = undef,
   $ssl_client_certs     = 'puppet:///modules/mcollective/empty',
-  $ssl_client_certs_dir = undef, # default dependent on $confdir
+  $ssl_client_certs_dir = undef, # default dependent on $confdir,
+
+  # misc settings
+  $show_diff            = true
+
 ) inherits mcollective::defaults {
 
   # Because the correct default value for several parameters is based on another

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -5,11 +5,12 @@ class mcollective::server::config {
   }
 
   datacat { 'mcollective::server':
-    owner    => 'root',
-    group    => '0',
-    mode     => '0400',
-    path     => $mcollective::server_config_file_real,
-    template => 'mcollective/settings.cfg.erb',
+    owner     => 'root',
+    group     => '0',
+    mode      => '0400',
+    path      => $mcollective::server_config_file_real,
+    template  => 'mcollective/settings.cfg.erb',
+    show_diff => $mcollective::show_diff,
   }
 
   mcollective::server::setting { 'classesfile':

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -29,12 +29,13 @@ define mcollective::user(
   }
 
   datacat { "mcollective::user ${username}":
-    path     => "${homedir}/.mcollective",
-    collects => [ 'mcollective::user', 'mcollective::client' ],
-    owner    => $username,
-    group    => $group,
-    mode     => '0400',
-    template => 'mcollective/settings.cfg.erb',
+    path      => "${homedir}/.mcollective",
+    collects  => [ 'mcollective::user', 'mcollective::client' ],
+    owner     => $username,
+    group     => $group,
+    mode      => '0400',
+    template  => 'mcollective/settings.cfg.erb',
+    show_diff => $mcollective::show_diff,
   }
 
   if $middleware_ssl or $securityprovider == 'ssl' {


### PR DESCRIPTION
Adding an option to allow to enable or disable diffs when running Puppet.

I run mcollective in a secure environment, and allowing diffs to output passwords to logs and reports is not an option.

This defaults to true, but enables us to turn it off.

I'm not sure how to spec this, so if anyone has any ideas for testing please let me know!