### PR TITLE
Revert "Fix ssl settings"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,8 +75,6 @@ class mcollective (
   $server_config_file_real = pick($server_config_file, "${confdir}/server.cfg")
   $client_config_file_real = pick($client_config_file, "${confdir}/client.cfg")
   $ssl_client_certs_dir_real = pick($ssl_client_certs_dir, "${confdir}/clients")
-  $ssl_server_public_real = pick($ssl_server_public, "${mcollective::confdir}/server_public.pem")
-  $ssl_server_private_real = pick($ssl_server_private, "${mcollective::confdir}/server_public.pem")
 
   if $client or $server {
     contain mcollective::common

--- a/manifests/server/config/securityprovider/ssl.pp
+++ b/manifests/server/config/securityprovider/ssl.pp
@@ -19,10 +19,10 @@ class mcollective::server::config::securityprovider::ssl {
   }
 
   mcollective::server::setting { 'plugin.ssl_server_public':
-    value => $mcollective::ssl_server_public_real,
+    value => "${mcollective::confdir}/server_public.pem",
   }
 
   mcollective::server::setting { 'plugin.ssl_server_private':
-    value => $mcollective::ssl_server_private_real,
+    value => "${mcollective::confdir}/server_private.pem",
   }
 }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -367,12 +367,6 @@ describe 'mcollective' do
             let(:params) { { :server => true, :securityprovider => 'ssl', :ssl_client_certs => 'puppet:///modules/foo/clients' } }
             it { should contain_file('/etc/mcollective/clients').with_source('puppet:///modules/foo/clients') }
           end
-
-          context 'set' do
-            let(:params) { { :server => true, :securityprovider => 'ssl', :ssl_server_public => '/etc/foo/server_public.pem', :ssl_server_private => '/etc/foo/server_private.pem' } }
-            it { should contain_mcollective__server__setting('plugin.ssl_server_public').with_value('/etc/foo/server_public.pem') }
-            it { should contain_mcollective__server__setting('plugin.ssl_server_private').with_value('/etc/foo/server_private.pem') }
-          end
         end
       end
 


### PR DESCRIPTION
Reverts puppet-community/puppet-mcollective#244

This breaks the currently documented handling of these features. The parameters are used as the source of the content of the files, not the filenames. Please revert to original behavior.