### PR TITLE
Fix broken refresh-mcollective-metadata

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,9 +7,10 @@ class mcollective::server::config::factsource::yaml (
   }
 
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
-  $ruby_shebang_path   = defined('$is_pe') and $::is_pe ? {
-    true    => '/opt/puppet/bin/ruby',
-    default => '/usr/bin/env ruby',
+  if defined('$is_pe') and $::is_pe {
+    $ruby_shebang_path = '/opt/puppet/bin/ruby'
+  } else {
+    $ruby_shebang_path = '/usr/bin/env ruby'
   }
   $yaml_fact_cron      = $mcollective::yaml_fact_cron
 

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -146,6 +146,20 @@ describe 'mcollective' do
           end
         end
 
+        describe '#ruby_shebang_path' do
+          context 'when is_pe undefined' do
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/usr/bin/env ruby}) }
+          end
+          context 'when is_pe == true' do
+            let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => true } }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/opt/puppet/bin/ruby}) }
+          end
+          context 'when is_pe == false' do
+            let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => false } }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/usr/bin/env ruby}) }
+          end
+        end
+
         describe '#yaml_fact_cron' do
           context 'default (true)' do
             it { should contain_cron('refresh-mcollective-metadata') }


### PR DESCRIPTION
Fix regression caused by
https://github.com/puppet-community/puppet-mcollective/commit/8a94a8ad0705a831c97f68b344be7495e2b3d6e2

$ruby_shebang_path was ending up being either true or false, not the
string expected.

Fixed by changing to a simple if/else.

I *think* that the selector code should have worked in puppet 4 (but
didn't - maybe a puppet bug??).

According to the docs, it would never have worked in puppet 3 as
'Control variables in selectors must be variables or functions that
return values. You cannot use expressions as control variables.'

https://docs.puppetlabs.com/puppet/3.8/reference/lang_conditional.html#selectors