### PR TITLE
Make server_daemonize a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ String: defaults to 'info'.  Level the mcollective server should log at.
 
 ##### `server_daemonize`
 
-String: defaults to '1'.  Should the mcollective server daemonize when
+Boolean: defaults to true.  Should the mcollective server daemonize when
 started.
 
 ##### `client_config_file`

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -25,9 +25,9 @@ class mcollective::defaults {
     $site_libdir = '/opt/puppetlabs/mcollective'
   }
 
-if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '14.10') < 0)
-  { $server_daemonize = '0' }
+  if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '14.10') <= 0)
+  { $server_daemonize = false } #https://tickets.puppetlabs.com/browse/MCO-167
   else
-  { $server_daemonize = '1' }
+  { $server_daemonize = true }
 
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -17,7 +17,7 @@ class mcollective::server::config {
   }
 
   mcollective::server::setting { 'daemonize':
-    value => $mcollective::server_daemonize,
+    value => bool2num($::mcollective::server_daemonize),
   }
 
   mcollective::server::setting { 'logfile':

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -113,13 +113,46 @@ describe 'mcollective' do
     end
 
     describe '#server_daemonize' do
-      it 'should default to 1' do
+      it 'should default to true' do
         should contain_mcollective__server__setting('daemonize').with_value('1')
       end
-
-      context '0' do
-        let(:params) { { :server_daemonize => '0' } }
+      context 'when true' do
+        let(:params) { { :server_daemonize => true } }
+        it { should contain_mcollective__server__setting('daemonize').with_value('1') }
+      end
+      context 'when false' do
+        let(:params) { { :server_daemonize => false } }
         it { should contain_mcollective__server__setting('daemonize').with_value('0') }
+      end
+      describe '#backwards compatibility' do
+        context 'when \'1\'' do
+          let(:params) { { :server_daemonize => '1' } }
+          it { should contain_mcollective__server__setting('daemonize').with_value('1') }
+        end
+        context 'when \'0\'' do
+          let(:params) { { :server_daemonize => '0' } }
+          it { should contain_mcollective__server__setting('daemonize').with_value('0') }
+        end
+      end
+      describe '#Ubuntu workaround for https://tickets.puppetlabs.com/browse/MCO-167' do
+        context 'when on Ubuntu 14.04' do
+          let(:facts) { { :operatingsystem => 'Ubuntu', :operatingsystemrelease => '14.04' } }
+          it 'should default to false' do
+            should contain_mcollective__server__setting('daemonize').with_value('0')
+          end
+        end
+        context 'when on Ubuntu 14.10' do
+          let(:facts) { { :operatingsystem => 'Ubuntu', :operatingsystemrelease => '14.10' } }
+          it 'should default to false' do
+            should contain_mcollective__server__setting('daemonize').with_value('0')
+          end
+        end
+        context 'when on Ubuntu 15.04' do
+          let(:facts) { { :operatingsystem => 'Ubuntu', :operatingsystemrelease => '15.04' } }
+          it 'should default to true' do
+            should contain_mcollective__server__setting('daemonize').with_value('1')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #238
Backwards compatible change that allows server_daemonize to be given as
a proper boolean.

Also fixed slight issue with
https://github.com/puppet-community/puppet-mcollective/pull/230