### PR TITLE
Fix ruby_shebang_path broken when fact stringified

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
       ref: '0.5.0'
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.0.0'
   symlinks:
     mcollective: '#{source_dir}'

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,7 +7,7 @@ class mcollective::server::config::factsource::yaml (
   }
 
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
-  if defined('$is_pe') and str2bool("$::is_pe") {
+  if defined('$is_pe') and str2bool($::is_pe) {
     $ruby_shebang_path = '/opt/puppet/bin/ruby'
   } else {
     $ruby_shebang_path = '/usr/bin/env ruby'

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -7,7 +7,7 @@ class mcollective::server::config::factsource::yaml (
   }
 
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
-  if defined('$is_pe') and $::is_pe {
+  if defined('$is_pe') and str2bool("$::is_pe") {
     $ruby_shebang_path = '/opt/puppet/bin/ruby'
   } else {
     $ruby_shebang_path = '/usr/bin/env ruby'

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0"
+      "version_requirement": ">=4.0.0 < 5.0.0"
     }
   ]
 }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -192,7 +192,7 @@ describe 'mcollective' do
             it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/usr/bin/env ruby}) }
           end
 
-          #Facts aren't being stringified automatically.  Maybe an rspec-puppet/puppetlabs-spec-helper bug???
+          # Facts aren't being stringified automatically.  Maybe an rspec-puppet/puppetlabs-spec-helper bug???
           context 'when is_pe == \'true\'' do
             let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => 'true' } }
             it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/opt/puppet/bin/ruby}) }

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -191,6 +191,16 @@ describe 'mcollective' do
             let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => false } }
             it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/usr/bin/env ruby}) }
           end
+
+          #Facts aren't being stringified automatically.  Maybe an rspec-puppet/puppetlabs-spec-helper bug???
+          context 'when is_pe == \'true\'' do
+            let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => 'true' } }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/opt/puppet/bin/ruby}) }
+          end
+          context 'when is_pe == \'false\'' do
+            let(:facts) { { :osfamily => 'RedHat', :number_of_cores => '42', :non_string => 69, :facterversion => '2.4.4', :is_pe => 'false' } }
+            it { should contain_file('/usr/local/libexec/mcollective/refresh-mcollective-metadata').with_content(%r{#!/usr/bin/env ruby}) }
+          end
         end
 
         describe '#yaml_fact_cron' do


### PR DESCRIPTION
Sort of surprised the spec tests didn't already pix this up.  What's the
point of puppetlabs-spec-helper STRINGIFY_FACTS option otherwise??

Anyway...
Fixed following solution from
https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html#handling-boolean-facts-in-older-puppet-versions