### PR TITLE
Bump datacat version to use < 1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "richardc/datacat",
-      "version_requirement": "0.5.x"
+      "version_requirement": ">= 0.6.2 < 1.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
As part of our setup we are using librarian-puppet which is causing dependency issues with puppet-mcollective because of `richardc/puppet-datacat` version. I ran the tests and apparently there is nothing broken, also there are no major changes in datacat that could break this module.